### PR TITLE
Emphasize causal for non-native speakers

### DIFF
--- a/docs/runtime/garbage-collection.md
+++ b/docs/runtime/garbage-collection.md
@@ -59,9 +59,9 @@ free concurrency by adhering to the following principles:
 
     * **Actor behaviours are atomic**.
 
-    * **Message delivery is casual** - i.e. messages arrive before any
+    * **Message delivery is causal**. [Causal](https://www.google.com/search?q=causal+definition): messages arrive before any
   messages they may have caused, if they have the same destination. So
-  there needs to be some kind of casual ordering guarantee, but less
+  there needs to be some kind of causal ordering guarantee, but less
   requirements than with comparable concurrent, fast garbage
   collectors.
 

--- a/docs/types/static-vs-dynamic.md
+++ b/docs/types/static-vs-dynamic.md
@@ -28,7 +28,7 @@ The Pony type system offers a lot of guarantees, even more than other statically
 * There will never be a data race.
 * Your program will never deadlock.
 * Your code will always be capabilities-secure.
-* All message passing is causal.
+* All message passing is [causal](https://www.google.com/search?q=causal+definition). (Not ca**su**al!)
 
 Some of those will make sense right now. Some of them may not mean much to you yet (like capabilities-security and causal messaging), but we'll get to those concepts later on.
 


### PR DESCRIPTION
Issue https://github.com/ponylang/pony-tutorial/issues/50
* fixed typo in docs/runtime/garbage-collection.md
* emphasized causal in docs/types/static-vs-dynamic.md
* added search links for causal definition in both places