### PR TITLE
Have TravisCI build tutorial on push

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language:
+  - python
+install:
+  - sudo -H pip install mkdocs;
+script:
+  - if [[ $TRAVIS_BRANCH == 'master' && $TRAVIS_PULL_REQUEST == 'false' ]]; then
+      git remote add gh-token "https://${GH_TOKEN}@github.com/${TRAVIS_REPO_SLUG}";
+      git fetch gh-token && git fetch gh-token gh-pages:gh-pages;
+      mkdocs gh-deploy -v --clean --remote-name gh-token;
+    fi;

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Pony Tutorials
 
-This is the source code for generating the Pony tutorials. They are generated with [MkDocs](http://www.mkdocs.org).
+This is the source code for generating the Pony tutorials. They are generated 
+with [MkDocs](http://www.mkdocs.org).
 
 To install mkdocs:
 
@@ -14,8 +15,6 @@ To work on the docs locally, `cd` to the repo directory and:
 $ mkdocs serve
 ```
 
-This will give you a live-reloading local version of the docs. When you are ready to publish your changes, make sure you are sync'd with the repo and then:
-
-```
-$ mkdocs gh-deploy
-```
+This will give you a live-reloading local version of the docs. When you are
+ready to publish your changes, commit everything and push to GitHub. TravisCI
+rebuilds the tutorial any time you push to `master`.


### PR DESCRIPTION
@sylvanc you'll need to set up a personal access token that has "repo" access. Then set up a GH_TOKEN env variable for the TravisCI plan for pony-tutorial. Everything else should work after that.