### PR TITLE
Fix partial application example

### DIFF
--- a/docs/expressions/partial-application.md
+++ b/docs/expressions/partial-application.md
@@ -8,12 +8,12 @@ A simple case is to create a "callback" function. For example:
 class Foo
   var _f: F64 = 0
 
-  fun addmul(add: F64, mul: F64): F64 =>
+  fun ref addmul(add: F64, mul: F64): F64 =>
     _f = (_f + add) * mul
 
 class Bar
   fun apply() =>
-    let foo = Foo
+    let foo: Foo = Foo
     let f = foo~addmul(3)
     f(4)
 ```


### PR DESCRIPTION
The examples misse a 'ref' in the function declaration resulting
in it defaulting to 'box'. This causes an error when writing to
the objects field.

The apply method in Bar creates a Foo that defaults to 'iso' and
gives an error about aliasing. Providing a type declaration defaults
it to 'ref'.