### PR TITLE
Update default capability syntax

### DIFF
--- a/docs/capabilities/reference-capabilities.md
+++ b/docs/capabilities/reference-capabilities.md
@@ -162,7 +162,7 @@ means you are using the _default_ reference capability for that type, which is
 defined along with the type. Here's an example from the standard library:
 
 ```pony
-class String val
+class val String
 ```
 
 When we use a `String` we usually mean a string value, so we make `val` the 


### PR DESCRIPTION
The syntax for types default capabilities changed recently but the tutorial still uses the old version.