### PR TITLE
Update primitives documentation

### DIFF
--- a/types/primitives.md
+++ b/types/primitives.md
@@ -46,11 +46,9 @@ widths.
 ## Primitive initialisation and finalisation
 
 Primitives can have two special functions, `_init` and `_final`. `_init` is
-called before any actor starts. The function takes a parameter of type `Env`,
-like the `Main` actor. This allows access to command line arguments and
-standard output. `_final` is called after all actors have terminated. The
-function takes no parameter. The `_init` and `_final` functions for different
-primitives always run sequentially.
+called before any actor starts. `_final` is called after all actors have
+terminated. The two functions take no parameter. The `_init` and `_final`
+functions for different primitives always run sequentially.
 
 A common use case for this is initialising and cleaning up C libraries without
 risking untimely use by an actor.


### PR DESCRIPTION
Since [ponyc/14b174f](https://github.com/ponylang/ponyc/commit/14b174f89f7cba854ee6638c5638ffa6c27e9a45), a primitive `_init` function takes no parameter.