### PR TITLE
Remove confusing sentence to clarify reference capabilities section

### DIFF
--- a/capabilities/reference-capabilities.md
+++ b/capabilities/reference-capabilities.md
@@ -173,5 +173,4 @@ default reference capability for `String`.
 __So do I have to specify a reference capability when I define a type?__ Only 
 if you want to. There are sensible defaults that most types will use. These are 
 `ref` for classes, `val` for primitives (i.e. immutable references) and `tag` 
-for actors. So the default for any mutable reference capability is `iso` and the
-default for any immutable reference capability is `val`.
+for actors.


### PR DESCRIPTION
The following sentence at the end of the document was confusing: "So
the default for any mutable reference capability is iso and the
default for any immutable reference capability is val." After some
discussion we decided it didn't make sense and didn't belong in this
part of the documentation, so I've removed it.