### PR TITLE
Avoid hard-wrapping lines in markdown files.

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,73 +1,33 @@
 # Contributing to the Pony tutorial
 
-Hi there! Thanks for your interest in contributing to the Pony Tutorial. The
-book is being developed in Markdown and hosted at 
-[Gitbook](https://www.gitbook.com/book/ponylang/pony-tutorial/details). We
-welcome external contributors. In fact, we encourage them.
+Hi there! Thanks for your interest in contributing to the Pony Tutorial. The book is being developed in Markdown and hosted at [Gitbook](https://www.gitbook.com/book/ponylang/pony-tutorial/details). We welcome external contributors. In fact, we encourage them.
 
-Please note, that by submitting any content to the Pony Tutorial book you are
-agreeing that it can be licensed under our [license](LICENSE.md). Furthermore,
-you are testifying that you own the copyright to the submitted content and
-indemnify Pony Tutorial from any copyright claim that might result from your not
-being the authorized copyright holder.
+Please note, that by submitting any content to the Pony Tutorial book you are agreeing that it can be licensed under our [license](LICENSE.md). Furthermore, you are testifying that you own the copyright to the submitted content and indemnify Pony Tutorial from any copyright claim that might result from your not being the authorized copyright holder.
 
 ## How the tutorial is organized
 
-The tutorial layout is in the process of being reogranized. Previously, all
-content for the tutorial was stored in the `docs` directory. Within that,
-there were folders for each section of the book. The sections act as logical
-groupings for chapters they contain. For new sections, they should be added to
-the top level of the repo. When creating a new section, be sure to add an
-`index.md` file that has the name of section as a level one entry: `#` as well
-as an introductory paragraph or two for the section. After reading the
-introduction, a reader should have a good idea of the type of content covered by
-the chapters that make up the section.
+The tutorial layout is in the process of being reogranized. Previously, all content for the tutorial was stored in the `docs` directory. Within that, there were folders for each section of the book. The sections act as logical groupings for chapters they contain. For new sections, they should be added to the top level of the repo. When creating a new section, be sure to add an `index.md` file that has the name of section as a level one entry: `#` as well as an introductory paragraph or two for the section. After reading the introduction, a reader should have a good idea of the type of content covered by the chapters that make up the section.
 
 ## How to format chapters
 
-Each chapter should start with the title of the chapter as a level one header:
-`#` in Markdown. Each section of the page should appear as a second level
-heading: `##`. If you need to have any subsections, make them a third level
-heading: `###`. If you find yourself reaching for a forth level heading, stop
-and figure out a different way to present the info in that section.
+Each chapter should start with the title of the chapter as a level one header: `#` in Markdown. Each section of the page should appear as a second level heading: `##`. If you need to have any subsections, make them a third level heading: `###`. If you find yourself reaching for a forth level heading, stop and figure out a different way to present the info in that section.
 
-After the title, before diving into your first section, you should have some
-level of expository text that explains what the reader can expect to get out of
-reading the page.
+After the title, before diving into your first section, you should have some level of expository text that explains what the reader can expect to get out of reading the page.
 
-Please make sure to keep any individual line under 80 characters except in
-instance where that would break link with the markdown (which only happens if
-the linked text and url are more than 76 characters).
+Avoid hard-wrapping lines within paragraphs (using line breaks in the middle of or between sentences to make lines shorter than a certain length). Instead, turn on soft-wrapping in your editor and expect the documentation renderer to let the text flow to the width of the container.
 
 ## How to update the Table of Contents
 
-Table of contents is handled by the `Summary.md` file. Each section of the book
-will appear as a top level item in the list contained in `Summary.md`. Each
-topic in turn appears as sub item beneath that. If you added a new section,
-don't forget to link to both the section `index.md` as well as the content for
-your topic.
+Table of contents is handled by the `Summary.md` file. Each section of the book will appear as a top level item in the list contained in `Summary.md`. Each topic in turn appears as sub item beneath that. If you added a new section, don't forget to link to both the section `index.md` as well as the content for your topic.
 
 ## How to submit a pull request
 
-Once your content is done, please open a pull request against this repo with
-your changes. Based on the state of your particular PR, a number of requests for
-change might be requested:
+Once your content is done, please open a pull request against this repo with your changes. Based on the state of your particular PR, a number of requests for change might be requested:
 
 * Changes to the content
 * Change to where the content appears in the Table of Contents
 * Change to where the markdown file for the content is stored in the repo
 
-Be sure to keep your PR to a single topic or logical change. If you are working
-on multiple changes, make sure they are each on their own branch and that
-before creating a new branch that you are on the master branch (others multiple
-changes might end up in your pull request). To repeat, each PR should be for a
-single logical change. We request that you create a good commit messages as laid
-out in 
-['How to Write a Git Commit Message'](http://chris.beams.io/posts/git-commit/).
+Be sure to keep your PR to a single topic or logical change. If you are working on multiple changes, make sure they are each on their own branch and that before creating a new branch that you are on the master branch (others multiple changes might end up in your pull request). To repeat, each PR should be for a single logical change. We request that you create a good commit messages as laid out in ['How to Write a Git Commit Message'](http://chris.beams.io/posts/git-commit/).
 
-If your PR is for a single logical change (which is should be) but spans
-multiple commits, we'll ask you to squash them into a single commit before we
-merge. Steve Klabnik wrote a handy guide for that: 
-[How to squash commits in a GitHub pull request](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request).
-
-
+If your PR is for a single logical change (which is should be) but spans multiple commits, we'll ask you to squash them into a single commit before we merge. Steve Klabnik wrote a handy guide for that: [How to squash commits in a GitHub pull request](http://blog.steveklabnik.com/posts/2012-11-08-how-to-squash-commits-in-a-github-pull-request).

--- a/README.md
+++ b/README.md
@@ -1,160 +1,96 @@
 # Pony Tutorial
 
-Welcome to the Pony tutorial! If you're reading this, chances are you want to 
-learn Pony. That's great, we're going to make that happen.
+Welcome to the Pony tutorial! If you're reading this, chances are you want to learn Pony. That's great, we're going to make that happen.
 
-This tutorial is aimed at people who have some experience programming already. 
-It doesn't really matter if you know a little Python, or a bit of Ruby, or you 
-are a JavaScript hacker, or Java, or Scala, or C/C++, or Haskell, or OCaml: as 
-long as you've written some code before, you should be fine.
+This tutorial is aimed at people who have some experience programming already. It doesn't really matter if you know a little Python, or a bit of Ruby, or you are a JavaScript hacker, or Java, or Scala, or C/C++, or Haskell, or OCaml: as long as you've written some code before, you should be fine.
 
 ## What's Pony, anyway?
 
-Pony is an object-oriented, actor-model, capabilities-secure programming 
-language. It's __object-oriented__ because it has classes and objects, like 
-Python, Java, C++, and many other languages. It's __actor-model__ because it 
-has _actors_ (similar to Erlang or Akka). These behave like objects, but they 
-can also execute code _asynchronously_. Actors make Pony awesome. 
+Pony is an object-oriented, actor-model, capabilities-secure programming language. It's __object-oriented__ because it has classes and objects, like Python, Java, C++, and many other languages. It's __actor-model__ because it has _actors_ (similar to Erlang or Akka). These behave like objects, but they can also execute code _asynchronously_. Actors make Pony awesome.
 
 When we say Pony is __capabilities-secure__, we mean a few things:
 
 * It's type safe. Really type safe. There's a mathematical proof and everything.
-* It's memory safe. Ok, this comes with type safe, but it's still interesting. 
-There are no dangling pointers, no buffer overruns, heck, the language doesn't 
-even have the concept of _null_!
-* It's exception safe. There are no runtime exceptions. All exceptions have 
-defined semantics, and they are _always_ handled.
-* It's data-race free. Pony doesn't have locks or atomic operations or anything 
-like that. Instead, the type system ensures _at compile time_ that your 
-concurrent program can never have data races. So you can write highly 
-concurrent code and never get it wrong.
-* It's deadlock free. This one is easy, because Pony has no locks at all! So 
-they definitely don't deadlock, because they don't exist.
+* It's memory safe. Ok, this comes with type safe, but it's still interesting. There are no dangling pointers, no buffer overruns, heck, the language doesn't even have the concept of _null_!
+* It's exception safe. There are no runtime exceptions. All exceptions have defined semantics, and they are _always_ handled.
+* It's data-race free. Pony doesn't have locks or atomic operations or anything like that. Instead, the type system ensures _at compile time_ that your concurrent program can never have data races. So you can write highly concurrent code and never get it wrong.
+* It's deadlock free. This one is easy, because Pony has no locks at all! So they definitely don't deadlock, because they don't exist.
 
-We'll talk more about capabilities-security, including both __object 
-capabilities__ and __reference capabilities__ later.
+We'll talk more about capabilities-security, including both __object capabilities__ and __reference capabilities__ later.
 
 ## The Pony Philosophy: Get Stuff Done
 
-In the spirit of [Richard Gabriel](http://www.jwz.org/doc/worse-is-better.html), 
-the Pony philosophy is neither "the-right-thing" nor "worse-is-better". It is 
-"get-stuff-done".
+In the spirit of [Richard Gabriel](http://www.jwz.org/doc/worse-is-better.html), the Pony philosophy is neither "the-right-thing" nor "worse-is-better". It is "get-stuff-done".
 
-* Correctness. Incorrectness is simply not allowed. _It's pointless to try to 
-get stuff done if you can't guarantee the result is correct._
+* Correctness. Incorrectness is simply not allowed. _It's pointless to try to get stuff done if you can't guarantee the result is correct._
 
-* Performance. Runtime speed is more important than everything except 
-correctness. If performance must be sacrificed for correctness, try to come up 
-with a new way to do things. _The faster the program can get stuff done, the 
-better. This is more important than anything except a correct result._
+* Performance. Runtime speed is more important than everything except correctness. If performance must be sacrificed for correctness, try to come up with a new way to do things. _The faster the program can get stuff done, the better. This is more important than anything except a correct result._
 
-* Simplicity. Simplicity can be sacrificed for performance. It is more 
-important for the interface to be simple than the implementation. _The faster 
-the programmer can get stuff done, the better. It's ok to make things a bit 
-harder on the programmer to improve performance, but it's more important to 
-make things easier on the programmer than it is to make things easier on the 
-language/runtime._
+* Simplicity. Simplicity can be sacrificed for performance. It is more important for the interface to be simple than the implementation. _The faster the programmer can get stuff done, the better. It's ok to make things a bit harder on the programmer to improve performance, but it's more important to make things easier on the programmer than it is to make things easier on the language/runtime._
 
-* Consistency. Consistency can be sacrificed for simplicity or performance. 
+* Consistency. Consistency can be sacrificed for simplicity or performance.
 _Don't let excessive consistency get in the way of getting stuff done._
 
-* Completeness. It's nice to cover as many things as possible, but completeness 
-can be sacrificed for anything else. _It's better to get some stuff done now 
-than wait until everything can get done later._
+* Completeness. It's nice to cover as many things as possible, but completeness can be sacrificed for anything else. _It's better to get some stuff done now than wait until everything can get done later._
 
-The "get-stuff-done" approach has the same attitude towards correctness and 
-simplicity as "the-right-thing", but the same attitude towards consistency and 
-completeness as "worse-is-better". It also adds performance as a new principle, 
-treating it as the second most important thing (after correctness).
+The "get-stuff-done" approach has the same attitude towards correctness and simplicity as "the-right-thing", but the same attitude towards consistency and completeness as "worse-is-better". It also adds performance as a new principle, treating it as the second most important thing (after correctness).
 
 ## Guiding Principles
 
-Throughout the design and development of the language the following principles 
-should be adhered to.
+Throughout the design and development of the language the following principles should be adhered to.
 
 * Use the get-stuff-done approach.
 
-* Simple grammar. Language must be trivial to parse for both humans and 
-computers.
+* Simple grammar. Language must be trivial to parse for both humans and computers.
 
 * No loadable code. Everything is known to the compiler.
 
 * Fully type safe. There is no "trust me, I know what I'm doing" coercion.
 
-* Fully memory safe. There is no "this random number is really a pointer, 
-honest."
+* Fully memory safe. There is no "this random number is really a pointer, honest."
 
-* No crashes. A program that compiles should never crash (although it may hang 
-or do something unintended).
+* No crashes. A program that compiles should never crash (although it may hang or do something unintended).
 
-* Sensible error messages. Where possible use simple error messages for 
-specific error cases. It is fine to assume the programmer knows the definitions 
-of words in our lexicon, but avoid compiler or other computer science jargon.
+* Sensible error messages. Where possible use simple error messages for specific error cases. It is fine to assume the programmer knows the definitions of words in our lexicon, but avoid compiler or other computer science jargon.
 
-* Inherent build system. No separate applications required to configure or 
-build.
+* Inherent build system. No separate applications required to configure or build.
 
 * Aim to reduce common programming bugs through the use of restrictive syntax.
 
-* Provide a single, clean and clear way to do things rather than catering to 
-every programmer's preferred prejudices.
+* Provide a single, clean and clear way to do things rather than catering to every programmer's preferred prejudices.
 
-* Make upgrades clean. Do not try to merge new features with the ones they are 
-replacing, if something is broken remove it and replace it in one go. Where 
-possible provide rewrite utilities to upgrade source between language versions.
+* Make upgrades clean. Do not try to merge new features with the ones they are replacing, if something is broken remove it and replace it in one go. Where possible provide rewrite utilities to upgrade source between language versions.
 
-* Reasonable build time. Keeping down build time is important, but less 
-important than runtime performance and correctness.
+* Reasonable build time. Keeping down build time is important, but less important than runtime performance and correctness.
 
-* Allowing the programmer to omit some things from the code (default arguments, 
-type inference, etc) is fine, but fully specifying should always be allowed.
+* Allowing the programmer to omit some things from the code (default arguments, type inference, etc) is fine, but fully specifying should always be allowed.
 
-* No ambiguity. The programmer should never have to guess what the compiler 
-will do, or vice-versa.
+* No ambiguity. The programmer should never have to guess what the compiler will do, or vice-versa.
 
-* Document required complexity. Not all language features have to be trivial to 
-understand, but complex features must have full explanations in the docs to be 
-allowed in the language.
+* Document required complexity. Not all language features have to be trivial to understand, but complex features must have full explanations in the docs to be allowed in the language.
 
 * Language features should be minimally intrusive when not used.
 
-* Fully defined semantics. The semantics of all language features must be 
-available in the standard language docs. It is not acceptable to leave 
-behaviour undefined or "implementation dependent".
+* Fully defined semantics. The semantics of all language features must be available in the standard language docs. It is not acceptable to leave behaviour undefined or "implementation dependent".
 
-* Efficient hardware access must be available, but this does not have to 
-pervade the whole language.
+* Efficient hardware access must be available, but this does not have to pervade the whole language.
 
 * The standard library should be implemented in Pony.
 
-* Interoperability. Must be interoperable with other languages, but this may 
-require a shim layer if non primitive types are used.
+* Interoperability. Must be interoperable with other languages, but this may require a shim layer if non primitive types are used.
 
-* Avoid library pain. Use of 3rd party Pony libraries should be as easy as 
-possible, with no surprises. This includes writing and distributing libraries 
-and using multiple versions of a library in a single program.
+* Avoid library pain. Use of 3rd party Pony libraries should be as easy as possible, with no surprises. This includes writing and distributing libraries and using multiple versions of a library in a single program.
 
 ## More help
 
-Working your way through the tutorial but in need of more help? Not to worry,
-we have you covered.
+Working your way through the tutorial but in need of more help? Not to worry, we have you covered.
 
-If you are looking for an answer "right now", we suggest you give our IRC
-channel a try. It's #ponylang on Freenode. If you ask a question, be sure to
-hang around until you get an answer. If you don't get one, or IRC isn't your
-thing, we have a friendly [mailing list](https://groups.io/g/pony+user) you can
-try. Whatever your question is, it isn't dumb, and we won't get annoyed.
+If you are looking for an answer "right now", we suggest you give our IRC channel a try. It's #ponylang on Freenode. If you ask a question, be sure to hang around until you get an answer. If you don't get one, or IRC isn't your thing, we have a friendly [mailing list](https://groups.io/g/pony+user) you can try. Whatever your question is, it isn't dumb, and we won't get annoyed.
 
-Think you've found a bug? Check your understanding first by writing the mailing
-list. Once you know it's a bug, 
-[open an issue](https://github.com/ponylang/ponyc/issues).
+Think you've found a bug? Check your understanding first by writing the mailing list. Once you know it's a bug, [open an issue](https://github.com/ponylang/ponyc/issues).
 
 # Help us
 
-Found a typo in this tutorial? Perhaps something isn't clear? We welcome pull
-requests against the tutorial: 
-[https://github.com/ponylang/pony-tutorial](https://github.com/ponylang/pony-tutorial).
-Be sure to check out the 
-[contribution guidelines](https://github.com/ponylang/pony-tutorial/blob/master/CONTRIBUTING.md)
-before opening your PR. 
+Found a typo in this tutorial? Perhaps something isn't clear? We welcome pull requests against the tutorial: [https://github.com/ponylang/pony-tutorial](https://github.com/ponylang/pony-tutorial).
 
+Be sure to check out the [contribution guidelines](https://github.com/ponylang/pony-tutorial/blob/master/CONTRIBUTING.md) before opening your PR.

--- a/appendices/compiler-args.md
+++ b/appendices/compiler-args.md
@@ -1,41 +1,20 @@
 # Compiler Arguments
 
-`ponyc`, the compiler, is usually called in the project directory,
-where it finds the `.pony` files and its dependencies
-automatically. There it will create the binary based on the directory
-name. You can override this and tune the compilation with several
-options as described via `ponyc --help` and you can pass a seperate
-source directory as argument.
+`ponyc`, the compiler, is usually called in the project directory, where it finds the `.pony` files and its dependencies automatically. There it will create the binary based on the directory name. You can override this and tune the compilation with several options as described via `ponyc --help` and you can pass a seperate source directory as argument.
 
-   `ponyc [OPTIONS] <package directory>`
+```bash
+ponyc [OPTIONS] <package directory>
+```
 
-The most useful options are `--debug`, `--path` or just `-p`,
-`--output` or just `-o` and `--docs` or `-g`. With `-l` you can
-generate a C library, `lib<directory>`.
+The most useful options are `--debug`, `--path` or just `-p`, `--output` or just `-o` and `--docs` or `-g`. With `-l` you can generate a C library, `lib<directory>`.
 
-`--debug` will skip the LLVM optimizations passes. This should not be
-mixed up with `make config=debug`, the default make configuration
-target. `config=debug` will create DWARF symbols, and add slower
-assertions to ponyc, but not to the generated binaries. For those you
-can omit DWARF symbols with the `--strip` or `-s` option.
+`--debug` will skip the LLVM optimizations passes. This should not be mixed up with `make config=debug`, the default make configuration target. `config=debug` will create DWARF symbols, and add slower assertions to ponyc, but not to the generated binaries. For those you can omit DWARF symbols with the `--strip` or `-s` option.
 
-`--path` or `-p` take a `:` seperated pathlist as argument, and adds
-those to the compile-time library paths for the linker to find source
-packages and the native libraries, static or dynamic, being linked at
-compile-time or via the FFI at run-time. The system adds several paths
-already, e.g. on windows it queries the registry to find the compiler
-run-time paths, you can also use `use "lib:path"` statements in the
-source code and as final possibility you can add `-p` paths. But if
-you want the generated binary to accept such a path to find a dynamic
-library at your client system, you need to handle that in your source
-code by yourself. See the `options` package for this.
+`--path` or `-p` take a `:` seperated pathlist as argument, and adds those to the compile-time library paths for the linker to find source packages and the native libraries, static or dynamic, being linked at compile-time or via the FFI at run-time. The system adds several paths already, e.g. on windows it queries the registry to find the compiler run-time paths, you can also use `use "lib:path"` statements in the source code and as final possibility you can add `-p` paths. But if you want the generated binary to accept such a path to find a dynamic library at your client system, you need to handle that in your source code by yourself. See the `options` package for this.
 
-`--output` or `-o` takes a directory name where the final binary is
-created.
+`--output` or `-o` takes a directory name where the final binary is created.
 
-`--docs` or -`g` creates a directory of the package with documentation
-in [readthedocs.org](http://readthedocs.org) format, i.e. markdown
-with nice navigation.
+`--docs` or -`g` creates a directory of the package with documentation in [readthedocs.org](http://readthedocs.org) format, i.e. markdown with nice navigation.
 
 Let's study the documentation of the builtin stdlib:
 
@@ -44,20 +23,11 @@ Let's study the documentation of the builtin stdlib:
   ponyc packages/stdlib --docs && cd stdlib-docs && mkdocs serve
 ```
 
-And point your web browser to [http://127.0.0.1:8000](http://127.0.0.1:8000)
-serving a live-reloading local version of the docs.
+And point your web browser to [http://127.0.0.1:8000](http://127.0.0.1:8000) serving a live-reloading local version of the docs.
 
-Note that there is _no builtin debugger_ to interactively step through
-your program and interpret the results. But ponyc creates proper DWARF
-symbols and you can step through your programs with a conventional
-debugger, such as gdb or lldb.
+Note that there is _no builtin debugger_ to interactively step through your program and interpret the results. But ponyc creates proper DWARF symbols and you can step through your programs with a conventional debugger, such as gdb or lldb.
 
 
 # Runtime options for Pony programs
 
-Besides using the `options` package, there are also several builtin
-options for the generated binary (_not for use with ponyc_) starting
-with `--pony*`, see `ponyc --help`, to tweak runtime performance. You
-can override the number of initial threads, tune cycle detection
-(_CD_), the garbage collector and even turn off yield, which is not
-really recommended.
+Besides using the `options` package, there are also several builtin options for the generated binary (_not for use with ponyc_) starting with `--pony*`, see `ponyc --help`, to tweak runtime performance. You can override the number of initial threads, tune cycle detection (_CD_), the garbage collector and even turn off yield, which is not really recommended.

--- a/appendices/examples.md
+++ b/appendices/examples.md
@@ -1,7 +1,6 @@
 # Examples
 
-Small how do I examples for Pony. These will eventually find another home.
-Until then, they live here.
+Small how do I examples for Pony. These will eventually find another home. Until then, they live here.
 
 ## Enum with values
 ```pony
@@ -95,12 +94,12 @@ actor Main
 
   new create(env: Env) =>
     // The no of arguments
-    env.out.print(env.args.size().string()) 
+    env.out.print(env.args.size().string())
     for value in env.args.values() do
       env.out.print(value)
     end
     // Access the arguments the first one will always be the the appication name
-    try env.out.print(env.args(0)) end 
+    try env.out.print(env.args(0)) end
 ```
 
 ## How to use options
@@ -160,7 +159,7 @@ be fail() =>
 be assert_failed(msg: String) =>
 fun tag assert_true(actual: Bool, msg: String = "") ?
 fun tag expect_true(actual: Bool, msg: String = ""): Bool
-fun tag assert_false(actual: Bool, msg: String = "") ? 
+fun tag assert_false(actual: Bool, msg: String = "") ?
 fun tag expect_false(actual: Bool, msg: String = ""): Bool
 fun tag assert_error(test: ITest, msg: String = "") ?
 fun tag expect_error(test: ITest box, msg: String = ""): Bool

--- a/appendices/garbage-collection.md
+++ b/appendices/garbage-collection.md
@@ -1,70 +1,35 @@
 # Garbage Collection with Pony-ORCA
 
-Pony-ORCA is a fully concurrent protocol for garbage collection in the
-actor paradigm. It allows cheap and small actors to perform garbage
-collection concurrently with any number of other actors, and this
-number can go into the millions, since one actor needs only 256 bytes
-on 64bit systems. It does not require any form of synchronization
-across actors except those introduced through the actor paradigm,
-i.e. **message send** and **message receive**.
+Pony-ORCA is a fully concurrent protocol for garbage collection in the actor paradigm. It allows cheap and small actors to perform garbage collection concurrently with any number of other actors, and this number can go into the millions, since one actor needs only 256 bytes on 64bit systems. It does not require any form of synchronization across actors except those introduced through the actor paradigm, i.e. **message send** and **message receive**.
 
-Pony-ORCA, yes _the killer whale_, is based on ideas from ownership
-and deferred, distributed, weighted **reference counting**. It adapts
-messaging systems of actors to keep the reference count
-consistent. The main challenges in concurrent garbage collection is
-the detection of cycles of sleeping actors in the actors graph, in the
-presence of concurrent mutation of this graph. With message passing
-you get deferred direct reference counting, a dedicated actor for the
-detection of (cyclic) garbage, and a confirmation protocol (to deal
-with the mutation of the actor graph).
+Pony-ORCA, yes _the killer whale_, is based on ideas from ownership and deferred, distributed, weighted **reference counting**. It adapts messaging systems of actors to keep the reference count consistent. The main challenges in concurrent garbage collection is the detection of cycles of sleeping actors in the actors graph, in the presence of concurrent mutation of this graph. With message passing you get deferred direct reference counting, a dedicated actor for the detection of (cyclic) garbage, and a confirmation protocol (to deal with the mutation of the actor graph).
 
 1. _Soundness_: the technique collects only dead actors.
 
 2. _Completeness_: the technique collects all dead actors eventually.
 
-3. _Concurrency_: the technique does not require a stop-the-world
-   step, clocks, timestamps, versioning, thread coordination, actor
-   introspection, shared memory, read/write barriers or cache
-   coherency.
+3. _Concurrency_: the technique does not require a stop-the-world step, clocks, timestamps, versioning, thread coordination, actor introspection, shared memory, read/write barriers or cache coherency.
 
-The type system ensures at compile time that your program can 
-**never have data races**. It's **deadlock free**... Because Pony has **no
-locks**!
+The type system ensures at compile time that your program can **never have data races**. It's **deadlock free**... Because Pony has **no locks**!
 
-When an actor has completed local execution and has no pending
-messages on its queue, it is _blocked_. An actor is _dead_, if it is
-blocked and all actors that have a reference to it are blocked,
-transitively. Collection of dead actors depends on being able to
-collect closed cycles of blocked actors.
+When an actor has completed local execution and has no pending messages on its queue, it is _blocked_. An actor is _dead_, if it is blocked and all actors that have a reference to it are blocked, transitively. Collection of dead actors depends on being able to collect closed cycles of blocked actors.
 
-The Pony type system guarantees soundness and race and dead-lock
-free concurrency by adhering to the following principles:
+The Pony type system guarantees soundness and race and dead-lock free concurrency by adhering to the following principles:
 
 ## Pony-ORCA characteristics
 
-1. An actor may perform garbage collection concurrently other actors
-   while they are executing and kind of behaviour.
+1. An actor may perform garbage collection concurrently other actors while they are executing and kind of behaviour.
 
-2. An actor may decide whether to garbage collect an object solely
-   based on its own local state, without consultation with, or
-   inspecting the state of any other actor.
+2. An actor may decide whether to garbage collect an object solely based on its own local state, without consultation with, or inspecting the state of any other actor.
 
-3. No synchronization between actors is required during garbage
-   collection, other than potential message sends.
+3. No synchronization between actors is required during garbage collection, other than potential message sends.
 
-4. An actor may garbage collect between its normal behaviours, i.e. it
-   need not wait untils its message queue is empty.
+4. An actor may garbage collect between its normal behaviours, i.e. it need not wait untils its message queue is empty.
 
-5. Pony-ORCA can be applied to several other programming languages,
-   provided that the satisfy the following two requirements:
+5. Pony-ORCA can be applied to several other programming languages, provided that the satisfy the following two requirements:
 
     * **Actor behaviours are atomic**.
 
-    * **Message delivery is causal**. 
-    [Causal](https://www.google.com/search?q=causal+definition): messages 
-    arrive before any messages they may have caused, if they have the same
-    destination. So there needs to be some kind of causal ordering guarantee,
-    but less requirements than with comparable concurrent, fast garbage
-    collectors.
+    * **Message delivery is causal**. [Causal](https://www.google.com/search?q=causal+definition): messages arrive before any messages they may have caused, if they have the same destination. So there needs to be some kind of causal ordering guarantee, but less requirements than with comparable concurrent, fast garbage collectors.
 
 

--- a/appendices/index.md
+++ b/appendices/index.md
@@ -1,9 +1,3 @@
 # Appendix
 
-Welcome to the appendix; the land of misshapen and forgotten documentation. Ok,
-not really forgotten just.. 'lesser' sounds wrong. Some of this material could
-get some loving and be promoted to a full chapter, some is always going to be an
-appendix, some might be worthy of a short book unto itself. Right now though it
-lives here, have a look through. You'll findlexicon of standard Pony
-terminology, a symbol lookup cheatsheet that can help you locate documentation
-on all our funny symbols like ^, ! and much more.
+Welcome to the appendix; the land of misshapen and forgotten documentation. Ok, not really forgotten just.. 'lesser' sounds wrong. Some of this material could get some loving and be promoted to a full chapter, some is always going to be an appendix, some might be worthy of a short book unto itself. Right now though it lives here, have a look through. You'll findlexicon of standard Pony terminology, a symbol lookup cheatsheet that can help you locate documentation on all our funny symbols like ^, ! and much more.

--- a/appendices/lexicon.md
+++ b/appendices/lexicon.md
@@ -1,64 +1,43 @@
 # Pony Lexicon
 
-Words are hard. We can all be saying the same thing but do we _mean_ the same
-thing? It's tough to know. Hopefully this lexicon helps a little.
+Words are hard. We can all be saying the same thing but do we _mean_ the same thing? It's tough to know. Hopefully this lexicon helps a little.
 
 ## Terminology
 
 **Braces**: { }. Synonymous with curly brackets.
 
-**Brackets**: This term is ambiguous. In the UK it usually means ( ) in the US 
-is usually means [ ]. It should therefore be avoided for use for either of 
-these. Can be used as a general term for any unspecified grouping punctuation, 
-including { }.
+**Brackets**: This term is ambiguous. In the UK it usually means ( ) in the US is usually means [ ]. It should therefore be avoided for use for either of these. Can be used as a general term for any unspecified grouping punctuation, including { }.
 
-**Compatible type**: Two types are compatible if there can be any single object 
-which is an instance of both types. Note that a suitable type for the single 
-object does not have to have been defined, as long as it could be. For example, 
-any two traits are compatible because a class could be defined that provides 
-both of them, even if such a class has not been defined. Conversely, no two 
-classes can ever be compatible because no object can be an instance of both.
+**Compatible type**: Two types are compatible if there can be any single object which is an instance of both types. Note that a suitable type for the single object does not have to have been defined, as long as it could be. For example, any two traits are compatible because a class could be defined that provides both of them, even if such a class has not been defined. Conversely, no two classes can ever be compatible because no object can be an instance of both.
 
-**Compound type**: A type combining multiple other types, ie union, 
-intersection and tuple. Opposite of a single type.
+**Compound type**: A type combining multiple other types, ie union, intersection and tuple. Opposite of a single type.
 
 **Concrete type**: An actor, class or primitive.
 
 **Curly brackets**: { }. Synonymous with braces.
 
-**Declaration** and **definition**: synonyms for each other, we do not draw the 
-C distinction between forward declarations and full definitions.
+**Declaration** and **definition**: synonyms for each other, we do not draw the C distinction between forward declarations and full definitions.
 
-**Default method body**: Method body defined in a trait and optionally used by 
-concrete types.
+**Default method body**: Method body defined in a trait and optionally used by concrete types.
 
-**Entity**: Top level definition within a file, ie alias, trait, actor, class, 
-primitive.
+**Entity**: Top level definition within a file, ie alias, trait, actor, class, primitive.
 
 **Explicit type**: An actor, class or primitive.
 
 **Member**: Method or field.
 
-**Method**: Something callable on a concrete type / object. Function, behaviour 
-or constructor.
+**Method**: Something callable on a concrete type / object. Function, behaviour or constructor.
 
-**Override**: When a concrete type has its own body for a method with a default 
-body provided by a trait.
+**Override**: When a concrete type has its own body for a method with a default body provided by a trait.
 
 **Parentheses**: ( ). Synonymous with round brackets.
 
-**Provide**: An entity's usage of traits and the methods they contain. 
-Equivalent to implements or inherits from.
+**Provide**: An entity's usage of traits and the methods they contain. Equivalent to implements or inherits from.
 
 **Round brackets**: ( ). Synonymous with parentheses.
 
-**Single type**: Any type which is not defined as a collection of other types. 
-Actors, classes, primitives, traits and structural types are all single types. 
-Opposite of a compound type.
+**Single type**: Any type which is not defined as a collection of other types. Actors, classes, primitives, traits and structural types are all single types. Opposite of a compound type.
 
 **Square brackets**: [ ]
 
-**Trait clash**: A trait clashes with another type if it contains a method with 
-the same name, but incompatible signature as a method in the other type. A 
-clashing trait is incompatible with the other type. Traits can clash with 
-actors, classes, primitives, intersections, structural types and other traits.
+**Trait clash**: A trait clashes with another type if it contains a method with the same name, but incompatible signature as a method in the other type. A clashing trait is incompatible with the other type. Traits can clash with actors, classes, primitives, intersections, structural types and other traits.

--- a/appendices/memory-allocation.md
+++ b/appendices/memory-allocation.md
@@ -1,9 +1,6 @@
 # Memory Allocation at Runtime
 
-Pony is NULL-free, type-safe language, with no dangling pointers, no
-buffer overruns, but with a **very fast garbage collector**, so you
-don't have to worry about explicit memory allocation, if on the heap
-or stack, if in a threaded actor, or not.
+Pony is NULL-free, type-safe language, with no dangling pointers, no buffer overruns, but with a **very fast garbage collector**, so you don't have to worry about explicit memory allocation, if on the heap or stack, if in a threaded actor, or not.
 
 ## Fast, Safe and Cheap
 
@@ -14,29 +11,18 @@ or stack, if in a threaded actor, or not.
 
 ## But Caveat Emptor
 
-But pony can be used to create **C libraries** and pony can use
-external C libraries via the **FFI** which does not have this luxury,
+But pony can be used to create **C libraries** and pony can use external C libraries via the **FFI** which does not have this luxury,
 
-So you **can** use any external C library out there, but the question is if
-you **need to** and if you **should**.
+So you **can** use any external C library out there, but the question is if you **need to** and if you **should**.
 
-The biggest problem is external heap memory, created by an external
-FFI call, or created to support an external call. But external stack
-space might also need some thoughts, esp. when being created from
-actors.
+The biggest problem is external heap memory, created by an external FFI call, or created to support an external call. But external stack space might also need some thoughts, esp. when being created from actors.
 
-Pony has no **finalizers**, callbacks which are called by the garbage
-collector to free external memory, which was allocated by a FFI call.
-The garbage collector is _not timely_ (as with pure reference
-counting), it is not triggered immediately when some object goes out
-of scope.
+Pony has no **finalizers**, callbacks which are called by the garbage collector to free external memory, which was allocated by a FFI call. The garbage collector is _not timely_ (as with pure reference counting), it is not triggered immediately when some object goes out of scope.
 
-A blocked actor will keep it's memory allocated, only a dead actor
-will release it eventually.
+A blocked actor will keep it's memory allocated, only a dead actor will release it eventually.
 
 ## And, long-running actors
 
-might cause unexpected out of memory errors, since the GC is not yet triggered 
-on an out-of-memory segfault or stack exhaustion.
+might cause unexpected out of memory errors, since the GC is not yet triggered on an out-of-memory segfault or stack exhaustion.
 
 ...

--- a/appendices/platform-dependent-code.md
+++ b/appendices/platform-dependent-code.md
@@ -1,23 +1,15 @@
 # Platform dependent code
 
-The Pony libraries of course want to abstract platform differences.
-Sometimes you may want a use command that only works under certain
-circumstances, most commonly only on a particular OS or only for debug
-builds. You can do this by specifying a condition for a use command:
+The Pony libraries of course want to abstract platform differences. Sometimes you may want a use command that only works under certain circumstances, most commonly only on a particular OS or only for debug builds. You can do this by specifying a condition for a use command:
 
 ```pony
 use "foo" if linux
 use "bar" if (windows and debug)
 ```
 
-Use conditions can use any of the methods defined in `builtin/Platform` as 
-conditions.
-There are currently the following booleans defined:
-`freebsd`, `linux`, `osx`, `posix` => `(freebsd or linux or osx)`,
-`windows`, `x86`, `arm`, `lp64`, `llp64`, `ilp32`, `native128`, `debug`
+Use conditions can use any of the methods defined in `builtin/Platform` as conditions.
+There are currently the following booleans defined: `freebsd`, `linux`, `osx`, `posix` => `(freebsd or linux or osx)`, `windows`, `x86`, `arm`, `lp64`, `llp64`, `ilp32`, `native128`, `debug`
 
-They can also use the operators `and`, `or`, `xor` and `not`. As with other 
-expressions in Pony, parentheses __must__ be used to indicate precedence if 
-more than one of `and`, `or` and `xor` is used.
+They can also use the operators `and`, `or`, `xor` and `not`. As with other expressions in Pony, parentheses __must__ be used to indicate precedence if more than one of `and`, `or` and `xor` is used.
 
 Any use command whose condition evaluates to false is ignored.

--- a/appendices/symbol-lookup-cheatsheet.md
+++ b/appendices/symbol-lookup-cheatsheet.md
@@ -1,9 +1,6 @@
 # Pony Symbols
 
-Pony, like just about any other programming language, has plenty of odd symbols
-that make up its syntax. If you don't remember what one means, it can be hard
-to search for them. Below you'll find a table with various Pony symbols and
-what you should search the tutorial for in order to learn more about the symbol.
+Pony, like just about any other programming language, has plenty of odd symbols that make up its syntax. If you don't remember what one means, it can be hard to search for them. Below you'll find a table with various Pony symbols and what you should search the tutorial for in order to learn more about the symbol.
 
 |Symbol | Search Keywords|
 | --- | --- |
@@ -19,9 +16,7 @@ what you should search the tutorial for in order to learn more about the symbol.
 | `<:` | Subtype |
 
 
-Here is a more elaborate explanation of Pony's use of special characters:
-(a line with (2) or (3) means an alternate usage of the symbol of the previous 
-line)
+Here is a more elaborate explanation of Pony's use of special characters: (a line with (2) or (3) means an alternate usage of the symbol of the previous  line)
 
 |Symbol | Usage|
 | --- | --- |

--- a/appendices/whitespace.md
+++ b/appendices/whitespace.md
@@ -6,23 +6,17 @@ Well, it mostly isn't significant.
 
 ## Mostly insignificant whitespace
 
-Pony reads a bit like Python, which is a _whitespace significant_ language. 
-That is, the amount of indentation on a line means something in Python. In 
-Pony, the amount of indentation is meaningless.
+Pony reads a bit like Python, which is a _whitespace significant_ language. That is, the amount of indentation on a line means something in Python. In Pony, the amount of indentation is meaningless.
 
 That means Pony programmers can format their code in whatever way suits them.
 
 There are three exceptions:
 
-1. A `-` at the beginning of a line starts a new expression (unary negation), 
-whereas a `-` in the middle of an expression is a binary operator (subtraction).
-2. A `(` at the beginning of a line starts a new expression (a tuple), whereas 
-a `(` in the middle of an expression is a method call.
-3. A `[` at the beginning of a line starts a new expression (an array literal), 
-whereas a `[` in the middle of an expression is generic formal parameters.
+1. A `-` at the beginning of a line starts a new expression (unary negation), whereas a `-` in the middle of an expression is a binary operator (subtraction).
+2. A `(` at the beginning of a line starts a new expression (a tuple), whereas a `(` in the middle of an expression is a method call.
+3. A `[` at the beginning of a line starts a new expression (an array literal), whereas a `[` in the middle of an expression is generic formal parameters.
 
-That stuff may seem a little esoteric right now, but we'll explain it all 
-later. The `-` part should make sense though.
+That stuff may seem a little esoteric right now, but we'll explain it all later. The `-` part should make sense though.
 
 ```pony
 a - b
@@ -39,33 +33,21 @@ That means "first do a, then, in a new expression, do a unary negation of b".
 
 ## Semicolons
 
-In Pony, you don't end an expression with a `;`, unlike C, C++, Java, C#, etc. 
-In fact, you don't need to end it at all! The compiler knows when an expression 
-has finished, like Python or Ruby.
+In Pony, you don't end an expression with a `;`, unlike C, C++, Java, C#, etc. In fact, you don't need to end it at all! The compiler knows when an expression has finished, like Python or Ruby.
 
-However, sometimes it's convenient to put more than one expression on the same 
-line. When you want to do that, you __must__ separate them with a `;`.
+However, sometimes it's convenient to put more than one expression on the same line. When you want to do that, you __must__ separate them with a `;`.
 
-__Why? Can't the compiler tell an expression has finished?__ Yes, it can. The 
-compiler doesn't really need the `;`. However, it turns out the programmer 
-does! By requiring a `;` between expressions on the same line, the compiler can 
-catch some pretty common syntax errors for you.
+__Why? Can't the compiler tell an expression has finished?__ Yes, it can. The compiler doesn't really need the `;`. However, it turns out the programmer does! By requiring a `;` between expressions on the same line, the compiler can catch some pretty common syntax errors for you.
 
 ## Docstrings
 
-Including documentation in your code makes you awesome. If you do it, everyone 
-will love you.
+Including documentation in your code makes you awesome. If you do it, everyone will love you.
 
-Pony makes it easy by allowing you to put a __docstring__ on every type and on 
-every method. Just put a string literal right after declaring the type, or 
-right after the `=>` of a method, before writing the body. The compiler will 
-know what to do with them.
+Pony makes it easy by allowing you to put a __docstring__ on every type and on every method. Just put a string literal right after declaring the type, or right after the `=>` of a method, before writing the body. The compiler will know what to do with them.
 
-For traits and interfaces that have methods without bodies, you can put the 
-docstring after the method declaration, even though there is no `=>`.
+For traits and interfaces that have methods without bodies, you can put the docstring after the method declaration, even though there is no `=>`.
 
-By convention, a docstring should be a triple-quoted string, and it should use 
-Markdown for any formatting.
+By convention, a docstring should be a triple-quoted string, and it should use Markdown for any formatting.
 
 ```pony
 actor Main
@@ -87,9 +69,7 @@ trait Readable
 
 ## Comments
 
-Use __docstrings__ first! But if you need to put some comments in the 
-implementation of your methods, perhaps to explain what's happening on various 
-lines, you can use C++ style comments. In Pony, block comments can be nested.
+Use __docstrings__ first! But if you need to put some comments in the implementation of your methods, perhaps to explain what's happening on various lines, you can use C++ style comments. In Pony, block comments can be nested.
 
 ```pony
 // This is a line comment.

--- a/c-ffi/c-abi.md
+++ b/c-ffi/c-abi.md
@@ -1,16 +1,12 @@
 # C ABI
 
-The FFI support in pony uses the C application binary interface (ABI) to
-interface with native code. The C ABI is a calling convention, one of many,
-that allow objects from different programming languages to be used together.
+The FFI support in pony uses the C application binary interface (ABI) to interface with native code. The C ABI is a calling convention, one of many, that allow objects from different programming languages to be used together.
 
 ## Writing a C library for Pony
 
-Writing your own C library for use by Pony is almost as easy as using existing 
-libraries.
+Writing your own C library for use by Pony is almost as easy as using existing libraries.
 
-Let's look at a complete example of a C function we may wish to provide to Pony.
-A Jump Consistent Hash, for example, could be provided in pure Pony as follows:
+Let's look at a complete example of a C function we may wish to provide to Pony. A Jump Consistent Hash, for example, could be provided in pure Pony as follows:
 
 ```pony
 // Jump consistent hashing in pony, with an inline pseudo random generator
@@ -29,8 +25,7 @@ fun jch(key: U64, buckets: I64): I32 =>
   b.i32()
 ```
 
-Let's say we wish to compare the pure Pony performance to an existing C 
-function with the following header:
+Let's say we wish to compare the pure Pony performance to an existing C function with the following header:
 
 ```C
 #ifndef __JCH_H_
@@ -44,9 +39,7 @@ extern "C"
 #endif
 ```
 
-Note the use of `extern "C"`. If the library is built as C++ then we need to 
-tell the compiler not to mangle the function name, otherwise Pony won't be able 
-to find it. For libraries built as C this is not needed, of course.
+Note the use of `extern "C"`. If the library is built as C++ then we need to tell the compiler not to mangle the function name, otherwise Pony won't be able to find it. For libraries built as C this is not needed, of course.
 
 The implemented would be something like:
 
@@ -81,8 +74,7 @@ int32_t jch_chash(uint64_t key, uint32_t num_buckets)
 }
 ```
 
-We need to compile the native code to a shared library. This example is for OSX. 
-The exact details may vary on other platforms.
+We need to compile the native code to a shared library. This example is for OSX. The exact details may vary on other platforms.
 
 ```
 clang++ -fPIC -Wall -Wextra -O3 -g -MM jch.c >jch.d
@@ -90,12 +82,11 @@ clang++ -fPIC -Wall -Wextra -O3 -g   -c -o jch.o jch.c
 clang++ -shared -lm -o libjch.dylib jch.o
 ```
 
-The Pony code to use this new C library is just like the code we've already seen 
-for using C libraries.
+The Pony code to use this new C library is just like the code we've already seen for using C libraries.
 
 ```pony
-""" This is an example of pony integrating with native code via the builtin FFI 
-support 
+""" This is an example of pony integrating with native code via the builtin FFI
+support
 """
 
 use "lib:jch"
@@ -119,5 +110,4 @@ actor Main
     end
 ```
 
-We can now use ponyc to compile a native executable integrating pony and our C 
-library. And that's all we need to do.
+We can now use ponyc to compile a native executable integrating pony and our C library. And that's all we need to do.

--- a/c-ffi/callbacks.md
+++ b/c-ffi/callbacks.md
@@ -1,55 +1,34 @@
 # Callbacks
 
-Some C APIs let the programmer specify functions that should be called
-to do pieces of work. For example, the SQLite API has a function
-called `sqlite3_exec` that executes an SQL statement and calls a
-function given by the programmer on each row returned by that
-statement. The functions that are supplied by the programmer are known
-as "callback functions". Pony functions can be passed as callback
-functions, but there are a few conditions that must be met.
+Some C APIs let the programmer specify functions that should be called to do pieces of work. For example, the SQLite API has a function called `sqlite3_exec` that executes an SQL statement and calls a function given by the programmer on each row returned by that statement. The functions that are supplied by the programmer are known as "callback functions". Pony functions can be passed as callback functions, but there are a few conditions that must be met.
 
 ## Pony assumes that the receiver is the first argument to the C function
 
-You can imagine the C library or framework that calling a callback
-function like this:
+You can imagine the C library or framework that calling a callback function like this:
 
 ```
 callback(arg1, arg2, arg3);
 ```
-  
-If that callback function calls a Pony function, then Pony acts as
-though the following happened:
+
+If that callback function calls a Pony function, then Pony acts as though the following happened:
 
 ```
 arg1.callback(arg2, arg3)
 ```
 
-That is to say, the first argument in the call to the callback
-function is treated as the receiver of the Pony function call, and the
-other arguments are passed to the Pony function as arguments.
+That is to say, the first argument in the call to the callback function is treated as the receiver of the Pony function call, and the other arguments are passed to the Pony function as arguments.
 
-In most cases the call that sets up the callback allows the programmer
-to specify some piece of data that will always be passed to the
-callback function. When calling this setup function, you should
-specify the Pony object and function. For example, if the library
-provides a setup function called `setup` that takes a callback
-function and a user data object, and a Pony program has an object
-called `cbo` with a function `callback` that handles the callback,
-then `setup` would be called like this:
+In most cases the call that sets up the callback allows the programmer to specify some piece of data that will always be passed to the callback function. When calling this setup function, you should specify the Pony object and function. For example, if the library provides a setup function called `setup` that takes a callback function and a user data object, and a Pony program has an object called `cbo` with a function `callback` that handles the callback, then `setup` would be called like this:
 
 ```
 setup(addressof cbo.callback, cbo)
 ```
 
-It may seem redundant to use `cbo` twice, but the function must be
-associated with an object when it is referenced.
+It may seem redundant to use `cbo` twice, but the function must be associated with an object when it is referenced.
 
 ## An example
 
-Consider SQLite, mentioned earlier. When the client code calls
-`sqlite3_exec`, an SQL query is executed against a database, and the
-callback function is called for each row returned by the SQL
-statement. Here's the signature for `sqlite3_exec`:
+Consider SQLite, mentioned earlier. When the client code calls `sqlite3_exec`, an SQL query is executed against a database, and the callback function is called for each row returned by the SQL statement. Here's the signature for `sqlite3_exec`:
 
 ```
 typedef int (*sqlite3_callback)(void*,int,char**, char**);
@@ -70,16 +49,9 @@ char **pzErrMsg             /* Write error messages here */
 }
 ```
 
-`sqlite3_callback` is the type of the callback function that will be
-called by `sqlite3_exec` for each row returned by the `sql`
-statement. The first argument to the callback function is the pointer
-`pArg` that was passed to `sqlite3_exec`, the second argument is the
-number of columns in the row being processed, the third argument is
-data for each column, and the fourth argument is the name of each
-column.
+`sqlite3_callback` is the type of the callback function that will be called by `sqlite3_exec` for each row returned by the `sql` statement. The first argument to the callback function is the pointer `pArg` that was passed to `sqlite3_exec`, the second argument is the number of columns in the row being processed, the third argument is data for each column, and the fourth argument is the name of each column.
 
-Here's the skeleton of some Pony code that uses `sqlite3_exec` to
-query an SQLite database:
+Here's the skeleton of some Pony code that uses `sqlite3_exec` to query an SQLite database:
 
 ```pony
 class SQLiteClient
@@ -95,19 +67,6 @@ class SQLiteClient
     ...
 ```
 
-Focusing on the callback-related parts, the callback function is
-passed using `addressof this.callback` as the third argument to
-`sqlite3_exec`. The fouth argument is `this`, which will end up being
-the first argument when the callback function is called. The callback
-function is called in `sqlite3_exec` by the call to
-`xCallback`. Remember, as mentioned before, that the first argument to
-`xCallback` becomes the receiver in the call to the Pony function, all
-subsequent arguments are passed along to the Pony callback function in
-order. The parameters of `callback` are arranged to reflect this.
+Focusing on the callback-related parts, the callback function is passed using `addressof this.callback` as the third argument to `sqlite3_exec`. The fouth argument is `this`, which will end up being the first argument when the callback function is called. The callback function is called in `sqlite3_exec` by the call to `xCallback`. Remember, as mentioned before, that the first argument to `xCallback` becomes the receiver in the call to the Pony function, all subsequent arguments are passed along to the Pony callback function in order. The parameters of `callback` are arranged to reflect this.
 
-If the order of the arguments to the callback function are not such
-that the receiver object will be passed as the first argument, the
-programmer will need to write a "shim" function in C that accepts
-arguments in the order provided by the API and rearranges them to make
-a call to the Pony function with arguments in the order that Pony
-expects.
+If the order of the arguments to the callback function are not such that the receiver object will be passed as the first argument, the programmer will need to write a "shim" function in C that accepts arguments in the order provided by the API and rearranges them to make a call to the Pony function with arguments in the order that Pony expects.

--- a/c-ffi/calling-c.md
+++ b/c-ffi/calling-c.md
@@ -1,47 +1,26 @@
 # Calling C from Pony
 
-FFI is built into Pony and native libraries may be directly referenced
-in Pony code. There is no need to code or configure bindings, wrappers or 
-interfaces.
+FFI is built into Pony and native libraries may be directly referenced in Pony code. There is no need to code or configure bindings, wrappers or interfaces.
 
-Here's an example of an FFI call in Pony from the standard library. It looks 
-like a normal method call, with just a few differences:
+Here's an example of an FFI call in Pony from the standard library. It looks like a normal method call, with just a few differences:
 
 ```pony
 @fwrite[U64](data.cstring(), U64(1), data.size(), _handle)
 ```
 
-The main difference is the @ symbol before the function name. This is what tells 
-us it's an FFI call. Any time you see an @ in Pony there's an FFI going on.
+The main difference is the @ symbol before the function name. This is what tells us it's an FFI call. Any time you see an @ in Pony there's an FFI going on.
 
-The other key difference is that the return type of the function is specified 
-after the function name, in square brackets. This is because the compiler needs 
-to know what type the value returned is (if any), but has no way to determine 
-that, so it needs you to explicitly tell it.
+The other key difference is that the return type of the function is specified after the function name, in square brackets. This is because the compiler needs to know what type the value returned is (if any), but has no way to determine that, so it needs you to explicitly tell it.
 
-There are a few unusual things going on with the arguments to this FFI call as 
-well. For the second argument, for which we're passing the value 1, we've had to 
-specify that this is a U64. Again this is because the compiler needs to know 
-what size argument to use, but has no way to determine this.
+There are a few unusual things going on with the arguments to this FFI call as well. For the second argument, for which we're passing the value 1, we've had to specify that this is a U64. Again this is because the compiler needs to know what size argument to use, but has no way to determine this.
 
 ## Safely does it
 
-__It is VERY important that when calling FFI functions you MUST get the 
-parameter and return types right__. The compiler has no way to know what the 
-native code expects and will just believe whatever you do. Errors here can cause 
-invalid data to be passed to the FFI function or returned to Pony, which can 
-lead to program crashes.
+__It is VERY important that when calling FFI functions you MUST get the parameter and return types right__. The compiler has no way to know what the native code expects and will just believe whatever you do. Errors here can cause invalid data to be passed to the FFI function or returned to Pony, which can lead to program crashes.
 
-To help avoid bugs here Pony allows you to specify the type signatures of FFI 
-functions in advance. Whilst you must still get the types correct the arguments 
-you provide at each FFI call site are checked against the declared signature. 
-This means that you must get a type wrong, in the same way, in at least 2 places 
-for a bug to exist. This won't help if the argument types the native code 
-expects are different to what you think they are, but it will protect you 
-against trivial mistakes and simple typos.
+To help avoid bugs here Pony allows you to specify the type signatures of FFI functions in advance. Whilst you must still get the types correct the arguments you provide at each FFI call site are checked against the declared signature. This means that you must get a type wrong, in the same way, in at least 2 places for a bug to exist. This won't help if the argument types the native code expects are different to what you think they are, but it will protect you against trivial mistakes and simple typos.
 
-FFI signatures are declared using the `use` command. Here's an example from the 
-standard library:
+FFI signatures are declared using the `use` command. Here's an example from the standard library:
 
 ```pony
 use @SSL_CTX_ctrl[I32](ctx: Pointer[_SSLContext] tag, op: I32, arg: I32,
@@ -56,41 +35,25 @@ class SSLContext val
     @SSL_CTX_ctrl(_ctx, 32, 0x01000000, Pointer[U8])
 ```
 
-The @ symbol tells us that the use command is an FFI signature declaration. The 
-types specified here are considered authoritative and any FFI calls that differ 
-are considered to be an error.
+The @ symbol tells us that the use command is an FFI signature declaration. The types specified here are considered authoritative and any FFI calls that differ are considered to be an error.
 
-Note that we no longer need to specify the return type at the call site, since 
-the signature declaration has already told us what it is. However, it is 
-perfectly acceptable to specify it again if you want to.
+Note that we no longer need to specify the return type at the call site, since the signature declaration has already told us what it is. However, it is perfectly acceptable to specify it again if you want to.
 
-The use @ command can take a condition just like other use commands. This is 
-useful in this case, where the Windows version of SSL_CTX_ctrl has a slightly 
-different signature to other platforms.
+The use @ command can take a condition just like other use commands. This is useful in this case, where the Windows version of SSL_CTX_ctrl has a slightly different signature to other platforms.
 
 ## C types
 
-Many C functions require types that don't have an exact equivalent in Pony. A 
-variety of features are provided for these.
+Many C functions require types that don't have an exact equivalent in Pony. A variety of features are provided for these.
 
-For FFI functions that have no return value (ie they return `void` in C) the 
-return value specified should be `[None]`.
+For FFI functions that have no return value (ie they return `void` in C) the return value specified should be `[None]`.
 
-In Pony String is an object with a header and fields, but in C a `char*` is 
-simply a pointer to character data. The `.cstring()` function on String provides 
-us with a valid pointer to hand to C. Our fwrite example above makes use of this 
-for the first argument.
+In Pony String is an object with a header and fields, but in C a `char*` is simply a pointer to character data. The `.cstring()` function on String provides us with a valid pointer to hand to C. Our fwrite example above makes use of this for the first argument.
 
 Pony classes corresponds directly to pointers to the class in C.
 
-For C pointers to simple types, such as U64, the Pony `Pointer[]` polymorphic 
-type should be used, with a `tag` reference capability. `Pointer[U8] tag` should 
-be used for void*. This can be seen in our `SSL_CTX_ctrl` example above.
+For C pointers to simple types, such as U64, the Pony `Pointer[]` polymorphic type should be used, with a `tag` reference capability. `Pointer[U8] tag` should be used for void*. This can be seen in our `SSL_CTX_ctrl` example above.
 
-To pass pointers to values to C the `addressof` operator can be used 
-(previously `&`), just like taking an address in C. This is done in the standard 
-library to pass the address of a `U64` to an FFI function that takes a 
-`uint64_t*` as an out parameter:
+To pass pointers to values to C the `addressof` operator can be used (previously `&`), just like taking an address in C. This is done in the standard library to pass the address of a `U64` to an FFI function that takes a `uint64_t*` as an out parameter:
 
 ```pony
 var len = U64(0)
@@ -138,8 +101,7 @@ let e: EGLEvent = (4, 0, 0)
 ```
 
 ### Get and Pass Pointers to FFI
-To pass and receive pointers to c structs you need to declare pointer to 
-primitives
+To pass and receive pointers to c structs you need to declare pointer to primitives
 ```pony
 primitive _XDisplayHandle
 primitive _EGLDisplayHandle
@@ -157,20 +119,15 @@ end
 
 ## FFI functions raising errors
 
-FFI functions can raise Pony errors. Functions in existing C libraries are very 
-unlikely to do this, but support libraries specifically written for use with 
-Pony may well do.
+FFI functions can raise Pony errors. Functions in existing C libraries are very unlikely to do this, but support libraries specifically written for use with Pony may well do.
 
-FFI calls to functions that __might__ raise an error __must__ mark it as such by 
-adding a ? after the arguments. For example:
+FFI calls to functions that __might__ raise an error __must__ mark it as such by adding a ? after the arguments. For example:
 
 ```pony
 @os_send[U64](_event, data.cstring(), data.size()) ? // May raise an error
 ```
 
-If a signature declaration is used then that must be marked as possibly raising 
-an error in the same way. The FFI call site then does not have to mark it as 
-well, although doing so is allowed.
+If a signature declaration is used then that must be marked as possibly raising an error in the same way. The FFI call site then does not have to mark it as well, although doing so is allowed.
 
 ```pony
 use @os_send[U64](ev: Event, buf: Pointer[U8] tag, len: U64) ?

--- a/c-ffi/index.md
+++ b/c-ffi/index.md
@@ -1,16 +1,5 @@
 # Chapter 10: C FFI
 
-Pony supports integration with other native languages through the Foreign
-Function Interface (FFI). The FFI library provides a stable and portable API and
-high level programming interface allowing Pony to integrate with native
-libraries easily.
+Pony supports integration with other native languages through the Foreign Function Interface (FFI). The FFI library provides a stable and portable API and high level programming interface allowing Pony to integrate with native libraries easily.
 
-Note that calling C (or other low level languages) is inherently dangerous. C 
-code fundamentally has access to all memory in the process and can change any of 
-it, either deliberately or due to bugs. This is one of the language's most 
-useful, but also most dangerous, features. Calling well written, bug free, C 
-code will have no ill effects on your program. However, calling buggy or 
-malicious C code or calling C incorrectly can cause your Pony program to go 
-wrong, including corrupting data and crashing. Consequently all of Pony 
-guarantees regarding not crashing, memory safety and concurrent correctness can 
-be voided by calling FFI functions.
+Note that calling C (or other low level languages) is inherently dangerous. C code fundamentally has access to all memory in the process and can change any of it, either deliberately or due to bugs. This is one of the language's most useful, but also most dangerous, features. Calling well written, bug free, C code will have no ill effects on your program. However, calling buggy or malicious C code or calling C incorrectly can cause your Pony program to go wrong, including corrupting data and crashing. Consequently all of Pony guarantees regarding not crashing, memory safety and concurrent correctness can be voided by calling FFI functions.

--- a/c-ffi/linking-c.md
+++ b/c-ffi/linking-c.md
@@ -1,20 +1,16 @@
 # Linking to C Libraries
 
-If Pony code calls FFI functions, then those functions, or rather the libraries 
-containing them, must be linked into the Pony program.
+If Pony code calls FFI functions, then those functions, or rather the libraries containing them, must be linked into the Pony program.
 
 ## Use for external libraries
 
-To link an external library to Pony code another variant of the use command is 
-used. The "lib" specifier is used to tell the compiler you want to link to a 
-library. For example:
+To link an external library to Pony code another variant of the use command is used. The "lib" specifier is used to tell the compiler you want to link to a library. For example:
 
 ```pony
 use "lib:foo"
 ```
 
-As with other use commands a condition may be specified. This is particularly 
-useful when the library has slightly different names on different platforms.
+As with other use commands a condition may be specified. This is particularly useful when the library has slightly different names on different platforms.
 
 Here's a real example from the standard library:
 
@@ -32,19 +28,10 @@ primitive _SSLInit
   fun _init(env: Env) =>
     @SSL_load_error_strings[None]()
     @SSL_library_init[I32]()
-``` 
+```
 
-On Windows we use the libraries "libssl-32" and "libcrypto-32" and on other 
-platforms we use "ssl" and "crypto". These contain the FFI functions 
-SSL_library_init and SSL_load_error_strings (amongst others).
+On Windows we use the libraries "libssl-32" and "libcrypto-32" and on other platforms we use "ssl" and "crypto". These contain the FFI functions SSL_library_init and SSL_load_error_strings (amongst others).
 
-By default the Pony compiler will look for the libraries to link in the standard 
-places, however that is defined on the build platform. However, it may be 
-necessary to look in extra places. The `use "path:..."` command allows this. 
-The specified path is added to the library search paths for the remainder of 
-the current file. The example above uses this to add the path 
-"/usr/local/opt/libressl/lib" for OSX. This is required because the library is 
-provided by brew, which installs things outside the standard library search 
-paths.
+By default the Pony compiler will look for the libraries to link in the standard places, however that is defined on the build platform. However, it may be necessary to look in extra places. The `use "path:..."` command allows this. The specified path is added to the library search paths for the remainder of the current file. The example above uses this to add the path "/usr/local/opt/libressl/lib" for OSX. This is required because the library is provided by brew, which installs things outside the standard library search paths.
 
 If you are integrating with existing libraries, that is all you need to do.

--- a/capabilities/aliasing.md
+++ b/capabilities/aliasing.md
@@ -2,73 +2,49 @@
 
 __Aliasing__ means having more than one variable that points to the same object.
 
-In most programming languages, aliasing is pretty simple. You just assign some 
-variable to another variable, and there you go, you have an alias. The variable 
-you assign to has the same type (or some supertype) as what's being assigned to 
-it, and everything is fine.
+In most programming languages, aliasing is pretty simple. You just assign some variable to another variable, and there you go, you have an alias. The variable you assign to has the same type (or some supertype) as what's being assigned to it, and everything is fine.
 
 In Pony, that works for some reference capabilities, but not all.
 
 ## Aliasing and deny guarantees
 
-The reason for this is that the `iso` reference capability denies other `iso` 
-variables that point to the same object. That is, you can only have one `iso` 
-variable pointing to any given object. The same goes for `trn`.
+The reason for this is that the `iso` reference capability denies other `iso` variables that point to the same object. That is, you can only have one `iso` variable pointing to any given object. The same goes for `trn`.
 
 ```pony
 fun test(a: Wombat iso) =>
   var b: Wombat iso = a // Not allowed!
 ```
 
-Here we have some function that gets passed an isolated Wombat. If we try to 
-alias `a` by assigning it to `b`, we'll be breaking reference capability 
-guarantees so the compiler will stop us.
+Here we have some function that gets passed an isolated Wombat. If we try to alias `a` by assigning it to `b`, we'll be breaking reference capability guarantees so the compiler will stop us.
 
-__What can I alias an `iso` as?__ Since an `iso` says no other variable can be 
-used by _any_ actor to read from or write to that object, we can only create 
-aliases to an `iso` that can neither read nor write. Fortunately, we've got a 
-reference capability that does exactly that: `tag`. So we can do this and the 
-compiler will be happy:
+__What can I alias an `iso` as?__ Since an `iso` says no other variable can be used by _any_ actor to read from or write to that object, we can only create aliases to an `iso` that can neither read nor write. Fortunately, we've got a reference capability that does exactly that: `tag`. So we can do this and the compiler will be happy:
 
 ```pony
 fun test(a: Wombat iso) =>
   var b: Wombat tag = a // Allowed!
 ```
 
-__What about aliasing `trn`?__ Since a `trn` says no other variable can be used 
-by _any_ actor to write to that object, we need something that doesn't allow 
-writing, but also doesn't prevent our `trn` variable from writing. Fortunately, 
-we've got a reference capability that does that too: `box`. So we can do this 
-and the compiler will be happy:
+__What about aliasing `trn`?__ Since a `trn` says no other variable can be used by _any_ actor to write to that object, we need something that doesn't allow writing, but also doesn't prevent our `trn` variable from writing. Fortunately, we've got a reference capability that does that too: `box`. So we can do this and the compiler will be happy:
 
 ```pony
 fun test(a: Wombat trn) =>
   var b: Wombat box = a // Allowed!
 ```
 
-__What about aliasing other stuff?__ Everything else can be aliased as itself. 
-So `ref` can be aliased as `ref`, `val` can be aliased as `val`, `box` can be 
-aliased as `box` and `tag` can be aliased as `tag`.
+__What about aliasing other stuff?__ Everything else can be aliased as itself. So `ref` can be aliased as `ref`, `val` can be aliased as `val`, `box` can be aliased as `box` and `tag` can be aliased as `tag`.
 
 ## What counts as making an alias?
 
 There are two things that count as making an alias:
 
-1. When you __assign__ a value to a variable. This could be a local variable or 
-a field.
+1. When you __assign__ a value to a variable. This could be a local variable or a field.
 2. When you __pass__ a value as an argument to a method.
 
-In both cases, you are making a new _name_ for the object. This might be the 
-name of a local variable, the name of a field, or the name of a parameter to a 
-method.
+In both cases, you are making a new _name_ for the object. This might be the name of a local variable, the name of a field, or the name of a parameter to a method.
 
 ## Ephemeral types
 
-In Pony, every expression has a type. So what's the type of `consume a`? It's 
-not the same type as `a`, because it might not be possible to alias `a`. 
-Instead, it's an __ephemeral__ type. That is, it's a type for a value that 
-currently has no name (it might have a name through some other alias, but not 
-the one we just consumed or destructively read).
+In Pony, every expression has a type. So what's the type of `consume a`? It's not the same type as `a`, because it might not be possible to alias `a`. Instead, it's an __ephemeral__ type. That is, it's a type for a value that currently has no name (it might have a name through some other alias, but not the one we just consumed or destructively read).
 
 To show a type is ephemeral, we put a `^` at the end. For example:
 
@@ -77,18 +53,13 @@ fun test(a: Wombat iso): Wombat iso^ =>
   consume a
 ```
 
-Here, our function takes an isolated Wombat as a parameter, and returns an 
-ephemeral isolated Wombat.
+Here, our function takes an isolated Wombat as a parameter, and returns an ephemeral isolated Wombat.
 
-This is useful for dealing with `iso` and `trn` types, and for generic types, 
-but it's also important for constructors. A constructor always returns an 
-ephemeral type, because it's a new object.
+This is useful for dealing with `iso` and `trn` types, and for generic types, but it's also important for constructors. A constructor always returns an ephemeral type, because it's a new object.
 
 ## Alias types
 
-For the same reason Pony has ephemeral types, it also has alias types. An alias 
-type is a way of saying "whatever we can safely alias this thing as". It's only 
-needed when dealing with generic types, which we'll discuss later.
+For the same reason Pony has ephemeral types, it also has alias types. An alias type is a way of saying "whatever we can safely alias this thing as". It's only needed when dealing with generic types, which we'll discuss later.
 
 We indicate an alias type by putting a `!` at the end. Here's an example:
 
@@ -97,5 +68,4 @@ fun test(a: A) =>
   var b: A! = a
 ```
 
-Here, we're using `A` as a __type variable__, which we'll cover later. So `A!` 
-means "an alias of whatever type `A` is".
+Here, we're using `A` as a __type variable__, which we'll cover later. So `A!` means "an alias of whatever type `A` is".

--- a/capabilities/arrow-types.md
+++ b/capabilities/arrow-types.md
@@ -1,18 +1,12 @@
 # Arrow Types aka Viewpoints
 
-When we talked about __reference capability composition__ and 
-__viewpoint adaptation__, we dealt with cases where we know the reference 
-capability of the origin. However, sometimes we don't know the precise 
-reference capability of the origin.
+When we talked about __reference capability composition__ and __viewpoint adaptation__, we dealt with cases where we know the reference capability of the origin. However, sometimes we don't know the precise reference capability of the origin.
 
-When that happens, we can write a __viewpoint adapted type__, which we call an 
-__arrow type__ because we write it with an `->`.
+When that happens, we can write a __viewpoint adapted type__, which we call an __arrow type__ because we write it with an `->`.
 
 ## Using `this->` as a viewpoint
 
-A function with a `box` receiver can be called with a `ref` receiver or a `val` 
-receiver as well, since those are both subtypes of `box`. Sometimes, we want to 
-be able to talk about a type to take this into account. For example:
+A function with a `box` receiver can be called with a `ref` receiver or a `val` receiver as well, since those are both subtypes of `box`. Sometimes, we want to be able to talk about a type to take this into account. For example:
 
 ```pony
 class Wombat
@@ -21,60 +15,35 @@ class Wombat
   fun friend(): this->Wombat => _friend
 ```
 
-Here, we have a `Wombat`, and every `Wombat` has a friend that's also a 
-`Wombat` (lucky `Wombat`). In fact, it's a `Wombat ref`, since `ref` is the 
-default reference capability for a `Wombat` (since we didn't specify one). We 
-also have a function that returns that friend. It's got a `box` receiver 
-(because `box` is the default receiver reference capability for a function if 
-we don't specify it).
+Here, we have a `Wombat`, and every `Wombat` has a friend that's also a `Wombat` (lucky `Wombat`). In fact, it's a `Wombat ref`, since `ref` is the default reference capability for a `Wombat` (since we didn't specify one). We also have a function that returns that friend. It's got a `box` receiver (because `box` is the default receiver reference capability for a function if we don't specify it).
 
-So the return type would normally be a `Wombat box`. Why's that? Because, as we 
-saw earlier, when we read a `ref` field from a `box` origin, we get a `box`. In 
-this case, the origin is the receiver, which is a `box`.
+So the return type would normally be a `Wombat box`. Why's that? Because, as we saw earlier, when we read a `ref` field from a `box` origin, we get a `box`. In this case, the origin is the receiver, which is a `box`.
 
-But wait! What if we want a function that can return a `Wombat ref` when the 
-receiver is a `ref`, a `Wombat val` when the receiver is a `val`, and a 
-`Wombat box` when the receiver is a `box`? We don't want to have to write the 
-function three times.
+But wait! What if we want a function that can return a `Wombat ref` when the receiver is a `ref`, a `Wombat val` when the receiver is a `val`, and a `Wombat box` when the receiver is a `box`? We don't want to have to write the function three times.
 
-We use `this->`! In this case, `this->Wombat`. It means "a `Wombat ref` as seen 
-by the receiver".
+We use `this->`! In this case, `this->Wombat`. It means "a `Wombat ref` as seen by the receiver".
 
-We know at the _call site_ what the real reference capability of the receiver 
-is. So when the function is called, the compiler knows everything it needs to 
-know to get this right.
+We know at the _call site_ what the real reference capability of the receiver is. So when the function is called, the compiler knows everything it needs to know to get this right.
 
 ## Using a type parameter as a viewpoint
 
-We haven't covered generics yet, so this may seem a little weird. We'll cover 
-this again when we talk about generics (i.e. parameterised types), but we're 
-mentioning it here for completeness.
+We haven't covered generics yet, so this may seem a little weird. We'll cover this again when we talk about generics (i.e. parameterised types), but we're mentioning it here for completeness.
 
-Another time we don't know the precise reference capability of something is if 
-we are using a type parameter. Here's an example from the standard library:
+Another time we don't know the precise reference capability of something is if we are using a type parameter. Here's an example from the standard library:
 
 ```pony
 class ListValues[A, N: ListNode[A] box] is Iterator[N->A]
 ```
 
-Here, we have a `ListValues` type that has two type parameters, `A` and `N`. In 
-addition, `N` has a constraint: it has to be a subtype of `ListNode[A] box`. 
-That's all fine and well, but we also say the `ListValues[A, N]` provides 
-`Iterator[N->A]`. That's the interesting bit: we provide an interface that 
-let's us iterate over values of the type `N->A`.
+Here, we have a `ListValues` type that has two type parameters, `A` and `N`. In addition, `N` has a constraint: it has to be a subtype of `ListNode[A] box`. That's all fine and well, but we also say the `ListValues[A, N]` provides `Iterator[N->A]`. That's the interesting bit: we provide an interface that let's us iterate over values of the type `N->A`.
 
-That means we'll be returning objects of the type `A`, but the reference 
-capability will be the same as an object of type `N` would see an object of 
-type `A`.
+That means we'll be returning objects of the type `A`, but the reference capability will be the same as an object of type `N` would see an object of type `A`.
 
 ## Using `box->` as a viewpoint
 
-There's one more way we use arrow types, and it's also related to generics. 
-Sometimes we want to talk about a type parameter as it is seen by some unknown 
-type, _as long as that type can read the type parameter_.
+There's one more way we use arrow types, and it's also related to generics. Sometimes we want to talk about a type parameter as it is seen by some unknown type, _as long as that type can read the type parameter_.
 
-In other words, the unknown type will be a subtype of `box`, but that's all we 
-know. Here's an example from the standard library:
+In other words, the unknown type will be a subtype of `box`, but that's all we know. Here's an example from the standard library:
 
 ```pony
 interface Comparable[A: Comparable[A] box]
@@ -82,7 +51,4 @@ interface Comparable[A: Comparable[A] box]
   fun ne(that: box->A): Bool => not eq(that)
 ```
 
-Here, we say that something is `Comparable[A]` if and only if it has functions 
-`eq` and `ne` and those functions have a single parameter of type `box->A` and 
-return a `Bool`. In other words, whatever `A` is bound to, we only need to be 
-able to read it.
+Here, we say that something is `Comparable[A]` if and only if it has functions `eq` and `ne` and those functions have a single parameter of type `box->A` and return a `Bool`. In other words, whatever `A` is bound to, we only need to be able to read it.

--- a/capabilities/capability-subtyping.md
+++ b/capabilities/capability-subtyping.md
@@ -1,94 +1,38 @@
 # Capability Subtyping
 
-Subtyping is about _substitutability_. That is, if we need to supply a certain 
-type, what other types can we substitute instead? Reference capabilities factor 
-into this.
+Subtyping is about _substitutability_. That is, if we need to supply a certain type, what other types can we substitute instead? Reference capabilities factor into this.
 
 ## Simple substitution
 
-First, let's cover substitution without worrying about ephemeral types (`^`) or 
-alias types (`!`). The `<:` symbol means "is a subtype of" or alternatively 
-"can be substituted for".
+First, let's cover substitution without worrying about ephemeral types (`^`) or alias types (`!`). The `<:` symbol means "is a subtype of" or alternatively "can be substituted for".
 
-* `iso <: trn`. An `iso` is _read and write unique_, and a `trn` is just 
-_write unique_, so it's safe to substitute an `iso` for a `trn`.
-* `trn <: ref`. A `trn` is mutable and also _write unique_. A `ref` is mutable, 
-but makes no uniqueness guarantees. It's safe to substitute a `trn` for a `ref`.
-* `trn <: val`. This one is interesting. A `trn` is _write unique_ and a `val` 
-is _globally immutable_, so why is it safe to substitute a `trn` for a `val`? 
-The key is that, in order to do so, you have to _give up_ the `trn` you have. 
-If you give up the _only_ variable that can write to an object, you know that 
-no variable can write to it. That means it's safe to consider it 
-_globally immutable_.
-* `ref <: box`. A `ref` guarantees no _other_ actor can read from or write to 
-the object. A `box` just guarantees no _other_ actor can write to the object, 
-so it's safe to substitute a `ref` for a `box`.
-* `val <: box`. A `val` guarantees _no_ actor, not even this one, can write to 
-the object. A `box` just guarantees no _other_ actor can write to the object, 
-so it's safe to substitute a `val` for a `box`.
-* `box <: tag`. A `box` guarantees no other actor can write to the object, and 
-a `tag` makes no guarantees at all, so it's safe to substitute a `box` for a 
-`tag`.
+* `iso <: trn`. An `iso` is _read and write unique_, and a `trn` is just _write unique_, so it's safe to substitute an `iso` for a `trn`.
+* `trn <: ref`. A `trn` is mutable and also _write unique_. A `ref` is mutable, but makes no uniqueness guarantees. It's safe to substitute a `trn` for a `ref`.
+* `trn <: val`. This one is interesting. A `trn` is _write unique_ and a `val` is _globally immutable_, so why is it safe to substitute a `trn` for a `val`? The key is that, in order to do so, you have to _give up_ the `trn` you have. If you give up the _only_ variable that can write to an object, you know that no variable can write to it. That means it's safe to consider it _globally immutable_.
+* `ref <: box`. A `ref` guarantees no _other_ actor can read from or write to the object. A `box` just guarantees no _other_ actor can write to the object, so it's safe to substitute a `ref` for a `box`.
+* `val <: box`. A `val` guarantees _no_ actor, not even this one, can write to the object. A `box` just guarantees no _other_ actor can write to the object, so it's safe to substitute a `val` for a `box`.
+* `box <: tag`. A `box` guarantees no other actor can write to the object, and a `tag` makes no guarantees at all, so it's safe to substitute a `box` for a `tag`.
 
-Subtyping is _transitive_. That means that since `iso <: trn` and `trn <: ref` 
-and `ref <: box`, we also get `iso <: box`.
+Subtyping is _transitive_. That means that since `iso <: trn` and `trn <: ref` and `ref <: box`, we also get `iso <: box`.
 
 ## Aliased substitution
 
-Now let's consider what happens when we have an alias of a reference 
-capability. For example, if we have some `iso` and we alias it (without doing 
-a `consume` or a destructive read), the type we get is `iso!`, not `iso`.
+Now let's consider what happens when we have an alias of a reference capability. For example, if we have some `iso` and we alias it (without doing a `consume` or a destructive read), the type we get is `iso!`, not `iso`.
 
-* `iso! <: tag`. This is a pretty big change. Instead of being a subtype of 
-everything like `iso`, the only thing an `iso!` is a subtype of is `tag`. This 
-is because the `iso` still exists, and is still _read and write unique_. Any 
-alias can neither read from nor write to the object. That means an `iso!` can 
-only be a subtype of `tag`.
-* `trn! <: box`. This is a change too, but not as big a change. Since `trn` is 
-only _write unique_, it's ok for aliases to read from the object, but it's not 
-ok for aliases to write to the object. That means we could have `box` or `val` 
-aliases - except `val` guarantees that _no_ alias can write the the object! 
-Since our `trn` still exists, and can write to the object, a `val` alias would 
-break the guarantees that `val` makes. So a `trn!` can only be a subtype of 
-`box` (and, transitively, `tag` as well).
-* `ref! <: ref`. Since a `ref` only guarantees that _other_ actors can neither 
-read from nor write to the object, it's ok to make more `ref` aliases within 
-the same actor.
-* `val! <: val`. Since a `val` only guarantees that _no_ actor can write to the 
-object, its ok to make more `val` aliases, since they can't write to the object 
-wither.
-* `box! <: box`. A `box` only guarantees that _other_ actors can't write to the 
-object. Both `val` and `ref` make that guarantee too, so why can `box` only 
-alias as `box`? It's because we can't make _more_ guarantees when we alias 
-something. That means `box` can only alias as `box`.
-* `tag! <: tag`. A `tag` doesn't make any guarantees at all. Just like with a 
-`box`, we can't make more guarantees when we make a new alias, so a `tag` can 
-only alias as a `tag`.
+* `iso! <: tag`. This is a pretty big change. Instead of being a subtype of everything like `iso`, the only thing an `iso!` is a subtype of is `tag`. This is because the `iso` still exists, and is still _read and write unique_. Any alias can neither read from nor write to the object. That means an `iso!` can only be a subtype of `tag`.
+* `trn! <: box`. This is a change too, but not as big a change. Since `trn` is only _write unique_, it's ok for aliases to read from the object, but it's not ok for aliases to write to the object. That means we could have `box` or `val` aliases - except `val` guarantees that _no_ alias can write the the object! Since our `trn` still exists, and can write to the object, a `val` alias would break the guarantees that `val` makes. So a `trn!` can only be a subtype of `box` (and, transitively, `tag` as well).
+* `ref! <: ref`. Since a `ref` only guarantees that _other_ actors can neither read from nor write to the object, it's ok to make more `ref` aliases within the same actor.
+* `val! <: val`. Since a `val` only guarantees that _no_ actor can write to the object, its ok to make more `val` aliases, since they can't write to the object wither.
+* `box! <: box`. A `box` only guarantees that _other_ actors can't write to the object. Both `val` and `ref` make that guarantee too, so why can `box` only alias as `box`? It's because we can't make _more_ guarantees when we alias something. That means `box` can only alias as `box`.
+* `tag! <: tag`. A `tag` doesn't make any guarantees at all. Just like with a `box`, we can't make more guarantees when we make a new alias, so a `tag` can only alias as a `tag`.
 
 ## Ephemeral substitution
 
-The last case to consider is when we have an ephemeral reference capability. 
-For example, if we have some `iso` and we `consume` it or do a destructive 
-read, the type we get is `iso^`, not `iso`.
+The last case to consider is when we have an ephemeral reference capability. For example, if we have some `iso` and we `consume` it or do a destructive read, the type we get is `iso^`, not `iso`.
 
-* `iso^ <: iso`. This is pretty simple. When we givean `iso^` a name, by 
-assigning it to something or passing it as an argument to a method, it loses 
-the `^` and becomes a plain old `iso`. We know we gave up our previous `iso`, 
-so it's safe to have a new one.
-* `trn^ <: trn`. This works exactly like `iso^`. The guarantee is weaker 
-(_write uniqueness_ instead of _read and write uniqueness_), but it works the 
-same way.
-* `ref^ <: ref^` and `ref^ <: ref` and `ref <: ref^`. Here, we have another 
-case. Not only is a `ref^` a subtype of a `ref`, it's also a subtype of a 
-`ref^`. What's going on here? The reason is that an ephemeral reference 
-capability is a way of saying "a reference capability that, when aliased, 
-results in the base reference capability". Since a `ref` can be aliased as a 
-`ref`, that means `ref` and `ref^` are completely interchangeable.
-* `val^`, `box^`, `tag^`. These all work the same way as `ref`, that is, they 
-are interchangeable with the base reference capability. It's for the same 
-reason: all of these reference capabilities can be aliased as themselves.
+* `iso^ <: iso`. This is pretty simple. When we givean `iso^` a name, by assigning it to something or passing it as an argument to a method, it loses the `^` and becomes a plain old `iso`. We know we gave up our previous `iso`, so it's safe to have a new one.
+* `trn^ <: trn`. This works exactly like `iso^`. The guarantee is weaker (_write uniqueness_ instead of _read and write uniqueness_), but it works the same way.
+* `ref^ <: ref^` and `ref^ <: ref` and `ref <: ref^`. Here, we have another case. Not only is a `ref^` a subtype of a `ref`, it's also a subtype of a `ref^`. What's going on here? The reason is that an ephemeral reference capability is a way of saying "a reference capability that, when aliased, results in the base reference capability". Since a `ref` can be aliased as a `ref`, that means `ref` and `ref^` are completely interchangeable.
+* `val^`, `box^`, `tag^`. These all work the same way as `ref`, that is, they are interchangeable with the base reference capability. It's for the same reason: all of these reference capabilities can be aliased as themselves.
 
-__Why do `ref^`, `val^`, `box^`, and `tag^` exist if they are interchangeable 
-with their base reference capabilities?__ It's for two reasons: 
-__reference capability recovery__ and __generics__. We'll cover both of those 
-later.
+__Why do `ref^`, `val^`, `box^`, and `tag^` exist if they are interchangeable with their base reference capabilities?__ It's for two reasons: __reference capability recovery__ and __generics__. We'll cover both of those later.

--- a/capabilities/combining-capabilities.md
+++ b/capabilities/combining-capabilities.md
@@ -1,20 +1,14 @@
 # Combining Capabilities
 
-When a field of an object is read, its reference capability depends both on the 
-reference capability of the field and the reference capability of the 
-__origin__, that is, the object the field is being read from.
+When a field of an object is read, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the field is being read from.
 
-This is because all the guarantees that the __origin__ reference capability 
-makes have to be maintained for its fields as well.
+This is because all the guarantees that the __origin__ reference capability makes have to be maintained for its fields as well.
 
 # Viewpoint adaptation
 
-The process of combining origin and field capabilties is called 
-__viewpoint adaptation__. That is, the __origin__ has a __viewpoint__, and can 
-"see" its fields only from that __viewpoint__.
+The process of combining origin and field capabilties is called __viewpoint adaptation__. That is, the __origin__ has a __viewpoint__, and can "see" its fields only from that __viewpoint__.
 
-Let's start with a table. This shows how __fields__ of each capability "look" 
-to __origins__ of each capability.
+Let's start with a table. This shows how __fields__ of each capability "look" to __origins__ of each capability.
 
 ---
 
@@ -29,8 +23,7 @@ to __origins__ of each capability.
 
 ---
 
-For example, if you have a `trn` origin and you read a `ref` field, you get a 
-`box` result:
+For example, if you have a `trn` origin and you read a `ref` field, you get a `box` result:
 
 ```pony
 class Foo
@@ -44,68 +37,41 @@ class Bar
 
 ## Explaining why
 
-That table will seem totally natural to you, eventually. But probably not yet. 
-To help it seem natural, let's walk through each cell in the table and explain 
-why it is the way it is.
+That table will seem totally natural to you, eventually. But probably not yet. To help it seem natural, let's walk through each cell in the table and explain why it is the way it is.
 
 ### Reading from an `iso` variable
 
-Anything read through an `iso` origin has to maintain the isolation guarantee 
-that the origin has. The key thing to remember is that the `iso` can be sent to 
-another actor and it can also become any other reference capability. So when we 
-read a field, we need to get a result that won't ever break the isolation 
-guarantees that the origin makes, that is, _read and write uniqueness_.
+Anything read through an `iso` origin has to maintain the isolation guarantee that the origin has. The key thing to remember is that the `iso` can be sent to another actor and it can also become any other reference capability. So when we read a field, we need to get a result that won't ever break the isolation guarantees that the origin makes, that is, _read and write uniqueness_.
 
-An `iso` field makes the same guarantees as an `iso` origin, so that's fine to 
-read. A `val` field is _globally immutable_, which means it's always ok to read 
-it, no matter what the origin is (well, other than `tag`).
+An `iso` field makes the same guarantees as an `iso` origin, so that's fine to read. A `val` field is _globally immutable_, which means it's always ok to read it, no matter what the origin is (well, other than `tag`).
 
-Everything else, though, can break our isolation guarantees. That's why other 
-reference capabilities are seen as `tag`: it's the only type that is neither 
-readable nor writeable.
+Everything else, though, can break our isolation guarantees. That's why other reference capabilities are seen as `tag`: it's the only type that is neither readable nor writeable.
 
 ### Reading from a `trn` variable
 
-This is like `iso`, but with a weaker guarantee (_write uniqueness_ as opposed 
-to _read and write uniqueness_). That makes a big difference, since now we can 
-return something readable when we enforce our guarantees.
+This is like `iso`, but with a weaker guarantee (_write uniqueness_ as opposed to _read and write uniqueness_). That makes a big difference, since now we can return something readable when we enforce our guarantees.
 
-An `iso` field makes stronger guarantees than a `trn` origin, and a `trn` field 
-makes the same guarantees, so they're fine to read. A `val` field is _globally 
-immutable_, so that's fine too. A `box` field is readable, and we only 
-guarantee _write uniqueness_, so that's fine too.
+An `iso` field makes stronger guarantees than a `trn` origin, and a `trn` field makes the same guarantees, so they're fine to read. A `val` field is _globally immutable_, so that's fine too. A `box` field is readable, and we only guarantee _write uniqueness_, so that's fine too.
 
 A `ref` field, though, would allow writing. So instead we return a `box`.
 
 ### Reading from a `ref` variable
 
-A `ref` origin doesn't modify its fields at all. This is because a `ref` origin 
-doesn't make any guarantees that are incompatible with its fields.
+A `ref` origin doesn't modify its fields at all. This is because a `ref` origin doesn't make any guarantees that are incompatible with its fields.
 
 ### Reading from a `val` variable
 
-A `val` origin is deeply and globally immutable, so all of its fields are also 
-`val`. The only exception is a `tag` field. Since we can't read from it, we 
-also can't guarantee that nobody can write to it, so it stays `tag`.
+A `val` origin is deeply and globally immutable, so all of its fields are also `val`. The only exception is a `tag` field. Since we can't read from it, we also can't guarantee that nobody can write to it, so it stays `tag`.
 
 ### Reading from a `box` variable
 
-A `box` variable is locally immutable. This means it's possible that it may be 
-mutated through some other variable (a `trn` or a `ref`), but it's also 
-possible that our `box` variable is an alias of some `val` variable.
+A `box` variable is locally immutable. This means it's possible that it may be mutated through some other variable (a `trn` or a `ref`), but it's also possible that our `box` variable is an alias of some `val` variable.
 
-When we read a field, we need to return a reference capability that is 
-compatible with the field, but is also locally immutable.
+When we read a field, we need to return a reference capability that is compatible with the field, but is also locally immutable.
 
-An `iso` field is returned as a `tag` because no locally immutable reference 
-capability can maintain its isolation guarantees. A `val` field is returned as 
-a `val` because global immutability is a stronger guarantee than local 
-immutability. A `box` field makes the same local immutability guarantee as its 
-origin, so that's also fine.
+An `iso` field is returned as a `tag` because no locally immutable reference capability can maintain its isolation guarantees. A `val` field is returned as a `val` because global immutability is a stronger guarantee than local immutability. A `box` field makes the same local immutability guarantee as its origin, so that's also fine.
 
-For `trn` and `ref` we need to return a locally immutable reference capability 
-that doesn't violate any guarantees the field makes. In both cases, we can 
-return `box`.
+For `trn` and `ref` we need to return a locally immutable reference capability that doesn't violate any guarantees the field makes. In both cases, we can return `box`.
 
 ### Reading from a `tag` variable
 

--- a/capabilities/consume-and-destructive-read.md
+++ b/capabilities/consume-and-destructive-read.md
@@ -1,28 +1,19 @@
 # Consume and Destructive Read
 
-And important part of Pony's capabilities are being able to say "I'm done with
-this thing". In this section, we're going to cover two means of doing that:
-consuming a variable and destructive reads.
+And important part of Pony's capabilities are being able to say "I'm done with this thing". In this section, we're going to cover two means of doing that: consuming a variable and destructive reads.
 
 ## Consuming a variable
 
-Sometimes, you want to _move_ an object from one variable to another. In other 
-words, you don't want to make a _new_ name for the object, exactly, you want to 
-move the object from some existing name to a different one.
+Sometimes, you want to _move_ an object from one variable to another. In other words, you don't want to make a _new_ name for the object, exactly, you want to move the object from some existing name to a different one.
 
-You can do this by using `consume`. When you `consume` a variable you take the 
-value out of it, effectively leaving the variable empty. No code can read from 
-that variable again until a new value is written to it. Consuming a local 
-variable or a parameter allows you to make an alias with the same type, even if 
-it's an `iso` or `trn`. For example:
+You can do this by using `consume`. When you `consume` a variable you take the value out of it, effectively leaving the variable empty. No code can read from that variable again until a new value is written to it. Consuming a local variable or a parameter allows you to make an alias with the same type, even if it's an `iso` or `trn`. For example:
 
 ```pony
 fun test(a: Wombat iso) =>
   var b: Wombat iso = consume a // Allowed!
 ```
 
-The compiler is happy with that, because by consuming `a`, you've said the 
-value can't be used again and the compiler will complain if you try to.
+The compiler is happy with that, because by consuming `a`, you've said the value can't be used again and the compiler will complain if you try to.
 
 ```pony
 fun test(a: Wombat iso) =>
@@ -30,21 +21,13 @@ fun test(a: Wombat iso) =>
   var c: Wombat tag = a // Not allowed!
 ```
 
-Here's an example of that. When you try to assign `a` to `c`, the compiler will 
-complain.
+Here's an example of that. When you try to assign `a` to `c`, the compiler will complain.
 
-__Can I `consume` a field?__ Definitely not! Consuming something means it is 
-empty, that is, it has no value. There's no way to be sure no other alias to 
-the object will access that field. If we tried to access a field that was 
-empty, we would crash. But there's a way to do what you want to do: 
-_destructive read_.
+__Can I `consume` a field?__ Definitely not! Consuming something means it is empty, that is, it has no value. There's no way to be sure no other alias to the object will access that field. If we tried to access a field that was empty, we would crash. But there's a way to do what you want to do: _destructive read_.
 
 ## Destructive read
 
-There's another way to _move_ a value from one name to another. Earlier, we 
-talked about how assignment in Pony returns the _old_ value of the left-hand 
-side, rather than the new value. This is called _destructive read_, and we can 
-use it to do what we want to do, even with fields.
+There's another way to _move_ a value from one name to another. Earlier, we talked about how assignment in Pony returns the _old_ value of the left-hand side, rather than the new value. This is called _destructive read_, and we can use it to do what we want to do, even with fields.
 
 ```pony
 class Aardvark
@@ -54,10 +37,6 @@ class Aardvark
     var b: Wombat iso = buddy = consume a // Allowed!
 ```
 
-Here, we consume `a`, assign it to the field `buddy`, and assign the _old_ 
-value of `buddy` to `b`.
+Here, we consume `a`, assign it to the field `buddy`, and assign the _old_ value of `buddy` to `b`.
 
-__Why is it ok to destructively read fields when we can't consume them?__ 
-Because when we do a destructive read, we assign to the field so it always has 
-a value. Unlike `consume`, there's no time when the field is empty. That means 
-it's safe and the compiler doesn't complain.
+__Why is it ok to destructively read fields when we can't consume them?__ Because when we do a destructive read, we assign to the field so it always has a value. Unlike `consume`, there's no time when the field is empty. That means it's safe and the compiler doesn't complain.

--- a/capabilities/guarantees.md
+++ b/capabilities/guarantees.md
@@ -1,87 +1,40 @@
 # Reference Capability Guarantees
 
-Since types are guarantees, it's useful to talk about what guarantees a 
-reference capability makes.
+Since types are guarantees, it's useful to talk about what guarantees a reference capability makes.
 
 ## What is denied
 
-We're going to talk about reference capability guarantees in terms of what's 
-_denied_. By this, we mean: what can other variables _not_ do when you have a 
-variable with a certain reference capability?
+We're going to talk about reference capability guarantees in terms of what's _denied_. By this, we mean: what can other variables _not_ do when you have a variable with a certain reference capability?
 
-We need to distinguish between the actor that contains the variable in question 
-and _other_ actors.
+We need to distinguish between the actor that contains the variable in question and _other_ actors.
 
-This is important because data reads and writes from other actors may occur 
-concurrently. If two actors can both read the same data and one of them changes 
-it then it will change under the feet of the other actor. This leads to 
-data-races and the need for locks. By ensuring this situation can never occur 
-Pony eliminates the need for locks.
+This is important because data reads and writes from other actors may occur concurrently. If two actors can both read the same data and one of them changes it then it will change under the feet of the other actor. This leads to data-races and the need for locks. By ensuring this situation can never occur Pony eliminates the need for locks.
 
-All code within any one actor always executes sequentially. This means that 
-data accesses from multiple variables within a single actor do not suffer from 
-data-races.
+All code within any one actor always executes sequentially. This means that data accesses from multiple variables within a single actor do not suffer from data-races.
 
 ## Mutable reference capabilities
 
-The __mutable__ reference capabilities are `iso`, `trn` and `ref`. These 
-reference capabilities are __mutable__ because they can be used to both read 
-from and write to an object.
+The __mutable__ reference capabilities are `iso`, `trn` and `ref`. These reference capabilities are __mutable__ because they can be used to both read from and write to an object.
 
-* If an actor has an `iso` variable, no other variable can be used by _any_ 
-actor to read from or write to that object. This means an `iso` variable is the 
-only variable anywhere in the program that can read from or write to that 
-object. It is _read and write unique_.
-* If an actor has a `trn` variable, no other variable can be used by _any_ 
-actor to write to that object, and no other variable can be used by _other_ 
-actors to read from or write to that object. This means a `trn` variable is the 
-only variable anywhere in the program that can write to that object, but other 
-variables held by the the same actor may be able to read from it. It is 
-_write unique_.
-* If an actor has a `ref` variable, no other variable can be used by _other_ 
-actors to read from or write to that object. This means that other variables 
-can be used to read from and write to the object, but only from within the same 
-actor.
+* If an actor has an `iso` variable, no other variable can be used by _any_ actor to read from or write to that object. This means an `iso` variable is the only variable anywhere in the program that can read from or write to that object. It is _read and write unique_.
+* If an actor has a `trn` variable, no other variable can be used by _any_ actor to write to that object, and no other variable can be used by _other_ actors to read from or write to that object. This means a `trn` variable is the only variable anywhere in the program that can write to that object, but other variables held by the the same actor may be able to read from it. It is _write unique_.
+* If an actor has a `ref` variable, no other variable can be used by _other_ actors to read from or write to that object. This means that other variables can be used to read from and write to the object, but only from within the same actor.
 
-__Why can they be used to write?__ Because they all stop _other_ actors from 
-reading from or writing to the object. Since we know no other actor will be 
-reading, it's safe for us to write to the object, without having to worry about 
-data-races. And since we know no other actor will be writing, it's safe for us 
-to read from the object, too.
+__Why can they be used to write?__ Because they all stop _other_ actors from reading from or writing to the object. Since we know no other actor will be reading, it's safe for us to write to the object, without having to worry about data-races. And since we know no other actor will be writing, it's safe for us to read from the object, too.
 
 ## Immutable reference capabilities
 
-The __immutable__ reference capabilities are `val` and `box`. These reference 
-capabilities are __immutable__ because they can be used to read from an object, 
-but not to write to it.
+The __immutable__ reference capabilities are `val` and `box`. These reference capabilities are __immutable__ because they can be used to read from an object, but not to write to it.
 
-* If an actor has a `val` variable, no other variable can be used by _any_ 
-actor to write to that object. This means that the object can't _ever_ change. 
-It is _globally immutable_.
-* If an actor has a `box` variable, no other variable can be used by _other_ 
-actors to write to that object. This means that other actors may be able to 
-read the object and other variables in the same actor may be able to write to 
-it (although not both). In either case it is safe for us to read. The object 
-is _locally immutable_.
+* If an actor has a `val` variable, no other variable can be used by _any_ actor to write to that object. This means that the object can't _ever_ change. It is _globally immutable_.
+* If an actor has a `box` variable, no other variable can be used by _other_ actors to write to that object. This means that other actors may be able to read the object and other variables in the same actor may be able to write to it (although not both). In either case it is safe for us to read. The object is _locally immutable_.
 
-__Why can they be used to read but not write?__ Because these reference 
-capabilities only stop _other_ actors from writing to the object. That means 
-there is no guarantee that _other_ actors aren't reading from the object, 
-which means it's not safe for us to write to it. It's safe for more than one 
-actor to read from an object at the same time though, so we're allowed to do 
-that.
+__Why can they be used to read but not write?__ Because these reference capabilities only stop _other_ actors from writing to the object. That means there is no guarantee that _other_ actors aren't reading from the object, which means it's not safe for us to write to it. It's safe for more than one actor to read from an object at the same time though, so we're allowed to do that.
 
 ## Opaque reference capabilities
 
-There's only one __opaque__ reference capability, which is `tag`. A `tag` 
-variable makes no guarantees about other variables at all. As a result, it 
-can't be used to either read from or write to the object.
+There's only one __opaque__ reference capability, which is `tag`. A `tag` variable makes no guarantees about other variables at all. As a result, it can't be used to either read from or write to the object.
 
-It's still useful though: you can do identity comparison with it, you can call 
-behaviours on it, and you can call functions on it that only need a `tag` 
-receiver.
+It's still useful though: you can do identity comparison with it, you can call behaviours on it, and you can call functions on it that only need a `tag` receiver.
 
-__Why can't `tag` be used to read or write?__ Because `tag` doesn't stop 
-_other_ actors from writing to the object. That means if we tried to read, we 
-would have no guarantee that there wasn't some other actor writing to the 
-object, so we might get a race condition.
+__Why can't `tag` be used to read or write?__ Because `tag` doesn't stop _other_ actors from writing to the object. That means if we tried to read, we would have no guarantee that there wasn't some other actor writing to the object, so we might get a race condition.

--- a/capabilities/index.md
+++ b/capabilities/index.md
@@ -1,49 +1,21 @@
 # Chapter 4: Capabilities
 
-We've covered the basics of Pony's type system and then expressions, this
-chapter about capabilities will cover another feature of Pony's type system. 
-There aren't currently any mainstream programming languages that feature
-capabilities. What is a capability?
+We've covered the basics of Pony's type system and then expressions, this chapter about capabilities will cover another feature of Pony's type system. There aren't currently any mainstream programming languages that feature capabilities. What is a capability?
 
-A capability is the the ability to do "something". Usually that "something" 
-involves an external resource that you might want access to; like the 
-filesystem or the network. This is called an object capability. Object 
-capabilities have appeared in a number of programming lanuages including 
-[E](https://en.wikipedia.org/wiki/E_(programming_language)).
+A capability is the the ability to do "something". Usually that "something" involves an external resource that you might want access to; like the filesystem or the network. This is called an object capability. Object capabilities have appeared in a number of programming lanuages including [E](https://en.wikipedia.org/wiki/E_(programming_language)).
 
-In addition to object capabilities, Pony also features another kind of
-capability, called a "reference capability". Where object capabilities are about
-being granted the ability to do things with objects, reference capabilities are
-about denying you the ability to do things with memory references. For example,
-"you can have access to this memory BUT ONLY for reading it. You can not write 
-to it". That's a reference capability and it's denying you access to do things.
+In addition to object capabilities, Pony also features another kind of capability, called a "reference capability". Where object capabilities are about being granted the ability to do things with objects, reference capabilities are about denying you the ability to do things with memory references. For example, "you can have access to this memory BUT ONLY for reading it. You can not write to it". That's a reference capability and it's denying you access to do things.
 
-Capabilities are core to what makes Pony special. You might remember in the
-introduction to this tutorial we said that Pony is:
+Capabilities are core to what makes Pony special. You might remember in the introduction to this tutorial we said that Pony is:
 
 * It's type safe. Really type safe. There's a mathematical proof and everything.
-* It's memory safe. Ok, this comes with type safe, but it's still interesting. 
-There are no dangling pointers, no buffer overruns, heck, the language doesn't 
-even have the concept of _null_!
-* It's exception safe. There are no runtime exceptions. All exceptions have 
-defined semantics, and they are _always_ handled.
-* It's data-race free. Pony doesn't have locks or atomic operations or anything 
-like that. Instead, the type system ensures _at compile time_ that your 
-concurrent program can never have data races. So you can write highly 
-concurrent code and never get it wrong.
-* It's deadlock free. This one is easy, because Pony has no locks at all! So 
-they definitely don't deadlock, because they don't exist.
+* It's memory safe. Ok, this comes with type safe, but it's still interesting. There are no dangling pointers, no buffer overruns, heck, the language doesn't even have the concept of _null_!
+* It's exception safe. There are no runtime exceptions. All exceptions have defined semantics, and they are _always_ handled.
+* It's data-race free. Pony doesn't have locks or atomic operations or anything like that. Instead, the type system ensures _at compile time_ that your concurrent program can never have data races. So you can write highly concurrent code and never get it wrong.
+* It's deadlock free. This one is easy, because Pony has no locks at all! So they definitely don't deadlock, because they don't exist.
 
 Object and reference capabilities are what make all that awesome possible.
 
-By the time you finish this chapter, you should start to have a handle on what
-capabilities are and how you can use them. Don't worry if you struggle with 
-them at first. For most people, its a new way of thinking about your code and
-takes a while to grasp. If you get stuck trying to get your capabilities right,
-definiitely reach out for help. Once you've used them for a couple weeks, 
-problems with capabilities start to melt away, but before that can be a real
-struggle. Don't worry, we all go through that struggle and the Pony community
-is waiting to help. Find us on IRC at #ponylang on Freenode or on the
-[mailing list](https://groups.io/g/pony+user). 
+By the time you finish this chapter, you should start to have a handle on what capabilities are and how you can use them. Don't worry if you struggle with them at first. For most people, its a new way of thinking about your code and takes a while to grasp. If you get stuck trying to get your capabilities right, definiitely reach out for help. Once you've used them for a couple weeks, problems with capabilities start to melt away, but before that can be a real struggle. Don't worry, we all go through that struggle and the Pony community is waiting to help. Find us on IRC at #ponylang on Freenode or on the [mailing list](https://groups.io/g/pony+user).
 
 Scared? Don't be. Ready? Good. Let's get started with object capabilities.

--- a/capabilities/object-capabilities.md
+++ b/capabilities/object-capabilities.md
@@ -1,60 +1,39 @@
 # Object Capabilities
 
-Pony's capabilities-secure type system is based on the object-capability model. 
-That sounds complicated, but really it's elegant and simple. The core idea is 
-this:
+Pony's capabilities-secure type system is based on the object-capability model. That sounds complicated, but really it's elegant and simple. The core idea is this:
 
-> A capability is an unforgeable token that (a) designates an object and (b) 
-gives the program the authority to perform a specific set of actions on that 
-object.
+> A capability is an unforgeable token that (a) designates an object and (b) gives the program the authority to perform a specific set of actions on that object.
 
-So what's that token? It's an address. A pointer. A reference. It's just... an 
-object.
+So what's that token? It's an address. A pointer. A reference. It's just... an object.
 
 ## How is that unforgeable?
 
-Since Pony has no pointer arithmetic, and is both type-safe and memory-safe, 
-object references can't be "invented" (i.e. forged) by the program. You can 
-only get one by constructing an object, or being passed an object.
+Since Pony has no pointer arithmetic, and is both type-safe and memory-safe, object references can't be "invented" (i.e. forged) by the program. You can only get one by constructing an object, or being passed an object.
 
-__What about the C FFI?__ Using the C FFI can break this guarantee. We'll talk 
-about the __C FFI trust boundary__ later, and how to control it.
+__What about the C FFI?__ Using the C FFI can break this guarantee. We'll talk about the __C FFI trust boundary__ later, and how to control it.
 
 ## What about global variables?
 
-They're bad! Because you can get them without either constructing them or being 
-passed them.
+They're bad! Because you can get them without either constructing them or being passed them.
 
-Global variables are a form of what is called _ambient authority_. Another form 
-of ambient authority is unfettered access to the file system.
+Global variables are a form of what is called _ambient authority_. Another form of ambient authority is unfettered access to the file system.
 
-Pony has no global variables and no global functions. That doesn't mean all 
-ambient authority is magically gone - we still need to be careful about the 
-file system, for example. Having no globals is necessary, but not sufficient, 
-to eliminate ambient authority.
+Pony has no global variables and no global functions. That doesn't mean all ambient authority is magically gone - we still need to be careful about the file system, for example. Having no globals is necessary, but not sufficient, to eliminate ambient authority.
 
-__Is this like referential transparency?__ Yes! It's similar. As long as you 
-think of the receiver as being passed to a method as well (which it is).
+__Is this like referential transparency?__ Yes! It's similar. As long as you think of the receiver as being passed to a method as well (which it is).
 
 ## How does this help?
 
-Instead of having permissions lists, access control lists, or other forms of 
-security, the object-capabilities model means that if you have a reference to 
-an object, you can do things with that object. Simple and effective.
+Instead of having permissions lists, access control lists, or other forms of security, the object-capabilities model means that if you have a reference to an object, you can do things with that object. Simple and effective.
 
-There's a great paper on how the object-capability model works, and it's pretty 
-easy reading:
+There's a great paper on how the object-capability model works, and it's pretty easy reading:
 
 [Capability Myths Demolished](http://srl.cs.jhu.edu/pubs/SRL2003-02.pdf)
 
 ## Capabilities and concurrency
 
-The object-capability model on its own does not address concurrency. It makes 
-clear _what_ will happen if there is simultaneous access to an object, but it 
-does not proscribe a single method of controlling this.
+The object-capability model on its own does not address concurrency. It makes clear _what_ will happen if there is simultaneous access to an object, but it does not proscribe a single method of controlling this.
 
-Combining capabilities with the actor-model is a good start, and has been done 
-before in languages such as [E](http://erights.org/) and Joule.
+Combining capabilities with the actor-model is a good start, and has been done before in languages such as [E](http://erights.org/) and Joule.
 
-Pony does this and also uses a system of _reference capabilities_ in the type 
-system.
+Pony does this and also uses a system of _reference capabilities_ in the type system.

--- a/capabilities/passing-and-sharing.md
+++ b/capabilities/passing-and-sharing.md
@@ -1,74 +1,40 @@
 # Passing and Sharing References
 
-Reference capabilities make it safe to both __pass__ mutable data between 
-actors and to __share__ immutable data amongst actors. Not only that, they make 
-it safe to do it with no copying, no locks, in fact no runtime overhead at all.
+Reference capabilities make it safe to both __pass__ mutable data between actors and to __share__ immutable data amongst actors. Not only that, they make it safe to do it with no copying, no locks, in fact no runtime overhead at all.
 
 ## Passing
 
-For an object to be mutable, we need to be sure that no _other_ actor can read 
-from or write to that object. The three mutable reference capabilities (`iso`, 
-`trn`, and `ref`) all make that guarantee.
+For an object to be mutable, we need to be sure that no _other_ actor can read from or write to that object. The three mutable reference capabilities (`iso`, `trn`, and `ref`) all make that guarantee.
 
-But what if we want to pass a mutable object from one actor to another? To do 
-that, we need to be sure that the actor that is _sending_ the mutable object 
-also _gives up_ the ability to both read from and write to that object.
+But what if we want to pass a mutable object from one actor to another? To do that, we need to be sure that the actor that is _sending_ the mutable object also _gives up_ the ability to both read from and write to that object.
 
-This is exactly what `iso` does. It is _read and write unique_, there can only 
-be one reference at a time that can be used for reading or writing. If you send 
-an `iso` object to another actor, you will be giving up the ability to read 
-from or write to that object.
+This is exactly what `iso` does. It is _read and write unique_, there can only be one reference at a time that can be used for reading or writing. If you send an `iso` object to another actor, you will be giving up the ability to read from or write to that object.
 
-__So I should use `iso` when I want to pass a mutable object between actors?__ 
-Yes! If you don't need to pass it, you can just use `ref` instead.
+__So I should use `iso` when I want to pass a mutable object between actors?__ Yes! If you don't need to pass it, you can just use `ref` instead.
 
 ## Sharing
 
-If you want to __share__ an object amongst actors, then we have to make one of 
-the following guarantees:
+If you want to __share__ an object amongst actors, then we have to make one of the following guarantees:
 
-1. Either _no_ actor can write to the object, in which case _any_ actor can 
-read from it, or
-2. Only _one_ actor can write to the object, in which case _other_ actors can 
-neither read from or write to the object.
+1. Either _no_ actor can write to the object, in which case _any_ actor can read from it, or
+2. Only _one_ actor can write to the object, in which case _other_ actors can neither read from or write to the object.
 
-The first guarantee is exactly what `val` does. It is _globally immutable_, so 
-we know that _no_ actor can ever write to that object. As a result, you can 
-freely send `val` objects to other actors, without needing to give up the 
-ability to read from that object.
+The first guarantee is exactly what `val` does. It is _globally immutable_, so we know that _no_ actor can ever write to that object. As a result, you can freely send `val` objects to other actors, without needing to give up the ability to read from that object.
 
-__So I should use `val` when I want to share an immutable object amongst 
-actors?__ Yes! If you don't need to share it, you can just use `ref` instead, 
-or `box` if you want it to be immutable.
+__So I should use `val` when I want to share an immutable object amongst actors?__ Yes! If you don't need to share it, you can just use `ref` instead, or `box` if you want it to be immutable.
 
-The second guarantee is what `tag` does. Not the part about only one actor 
-writing (that's guaranteed by any mutable reference capability), but the part 
-about not being able to read from or write to an object. That means you can 
-freely pass `tag` objects to other actors, without needing to give up the 
-ability to read from or write to that object.
+The second guarantee is what `tag` does. Not the part about only one actor writing (that's guaranteed by any mutable reference capability), but the part about not being able to read from or write to an object. That means you can freely pass `tag` objects to other actors, without needing to give up the ability to read from or write to that object.
 
-__What's the point in sending a tag reference to another actor if it can't then 
-read of write the fields?__ Because `tag` __can__ be used to __identify__ 
-objects and sometimes that's all you need. Also, if the object is an actor you 
-can call behaviours on it even though you only have a `tag`.
+__What's the point in sending a tag reference to another actor if it can't then read of write the fields?__ Because `tag` __can__ be used to __identify__ objects and sometimes that's all you need. Also, if the object is an actor you can call behaviours on it even though you only have a `tag`.
 
-__So I should use `tag` when I want to share the identity of a mutable object 
-amongst actors?__ Yes! Or, really, the identity of anything, whether it's 
-mutable, immutable, or even an actor.
+__So I should use `tag` when I want to share the identity of a mutable object amongst actors?__ Yes! Or, really, the identity of anything, whether it's mutable, immutable, or even an actor.
 
 ## Reference capabilities that can't be sent
 
-You may have noticed we didn't mention `trn`, `ref`, or `box` as things you can 
-send to other actors. That's because you can't do it. They don't make the 
-guarantees we need in order to be safe.
+You may have noticed we didn't mention `trn`, `ref`, or `box` as things you can send to other actors. That's because you can't do it. They don't make the guarantees we need in order to be safe.
 
 So when should you use those reference capabilities?
 
-* Use `ref` when you need to be able to change an object over time. On the 
-other hand, if your program wouldn't be any slower if you used an immutable 
-type instead, you may want to use a `val` anyway.
-* Use `box` when you don't care whether the object is mutable or immutable. In 
-other words, you want to be able to read from it, but you don't need to write 
-to it or share it with other actors.
-* Use `trn` when you want to be able to change an object for a while, but you 
-also want to be able to make it _globally immutable_ later.
+* Use `ref` when you need to be able to change an object over time. On the other hand, if your program wouldn't be any slower if you used an immutable type instead, you may want to use a `val` anyway.
+* Use `box` when you don't care whether the object is mutable or immutable. In other words, you want to be able to read from it, but you don't need to write to it or share it with other actors.
+* Use `trn` when you want to be able to change an object for a while, but you also want to be able to make it _globally immutable_ later.

--- a/capabilities/recovering-capabilities.md
+++ b/capabilities/recovering-capabilities.md
@@ -1,20 +1,13 @@
 # Recovering Capabilities
 
-A `recover` expression let's you "lift" the reference capability of the result. 
-A mutable reference capability (`iso`, `trn`, or `ref`) can become _any_ 
-reference capability, and an immutable reference capability (`val` or `box`) 
-can become any immutable or opaque reference capability.
+A `recover` expression let's you "lift" the reference capability of the result. A mutable reference capability (`iso`, `trn`, or `ref`) can become _any_ reference capability, and an immutable reference capability (`val` or `box`) can become any immutable or opaque reference capability.
 
 ## Why is this useful?
 
-This most straightforward use of `recover` is to get an `iso` that you can pass 
-to another actor. But it can be used for many other things as well, such as:
+This most straightforward use of `recover` is to get an `iso` that you can pass to another actor. But it can be used for many other things as well, such as:
 
-* Creating a cyclic immutable data structure. That is, you can create a complex 
-mutable data structure inside a `recover` expression, "lift" the resulting 
-`ref` to a `val`.
-* "Borrow" an `iso` as a `ref`, do a series of complex mutable operations on 
-it, and return it as an `iso` again.
+* Creating a cyclic immutable data structure. That is, you can create a complex mutable data structure inside a `recover` expression, "lift" the resulting `ref` to a `val`.
+* "Borrow" an `iso` as a `ref`, do a series of complex mutable operations on it, and return it as an `iso` again.
 * "Extract" a mutable field from an `iso` and return it as an `iso`.
 
 ## What does this look like?
@@ -23,8 +16,7 @@ it, and return it as an `iso` again.
 recover Array[String] end
 ```
 
-That's a simple one: it returns an `Array[String] iso`, instead of the usual 
-`Array[String] ref` you would get.
+That's a simple one: it returns an `Array[String] iso`, instead of the usual `Array[String] ref` you would get.
 
 Here's a more complicated example from the standard library:
 
@@ -52,71 +44,37 @@ recover
 end
 ```
 
-That's from `ToString`. It creates a `String ref`, does a bunch of stuff with 
-it, and finally returns it as a `String iso`.
+That's from `ToString`. It creates a `String ref`, does a bunch of stuff with it, and finally returns it as a `String iso`.
 
-Both of those examples use the default reference capability for a `recover` 
-expression, since they don't specify one. The default for any mutable reference 
-capability is `iso` and the default for any immutable reference capability is 
-`val`. You can also give an explicit one:
+Both of those examples use the default reference capability for a `recover` expression, since they don't specify one. The default for any mutable reference capability is `iso` and the default for any immutable reference capability is `val`. You can also give an explicit one:
 
 ```pony
 let key = recover val line.substring(0, i).strip() end
 ```
 
-That's from `net/http/_PayloadBuilder`. We get a substring of `line`, which is 
-a `String iso^`, then we call strip on it, which returns itself. But since strip 
-is a `ref` function, it returns itself as a `String ref^` - so we use a 
-`recover val` to end up with a `String val`.
+That's from `net/http/_PayloadBuilder`. We get a substring of `line`, which is a `String iso^`, then we call strip on it, which returns itself. But since strip is a `ref` function, it returns itself as a `String ref^` - so we use a `recover val` to end up with a `String val`.
 
 ## How does this work?
 
-Inside the `recover` expression, your code only has access to __sendable__ 
-values from the enclosing lexical scope. In other words, you can only use 
-`iso`, `val` and `tag` things from outside the `recover` expression.
+Inside the `recover` expression, your code only has access to __sendable__ values from the enclosing lexical scope. In other words, you can only use `iso`, `val` and `tag` things from outside the `recover` expression.
 
-This means that when the `recover` expression finishes, any aliases to the 
-result of the expression other than `iso`, `val` and `tag` ones won't exist any 
-more. That makes it safe to "lift" the reference capability of the result of 
-the expression.
+This means that when the `recover` expression finishes, any aliases to the result of the expression other than `iso`, `val` and `tag` ones won't exist any more. That makes it safe to "lift" the reference capability of the result of the expression.
 
-If the `recover` expression could access __non-sendable__ values from the 
-enclosing lexical scope, "lifting" the reference capability of the result 
-wouldn't be safe. Some of those values could "leak" into an `iso` or `val` 
-result, and result in data-races.
+If the `recover` expression could access __non-sendable__ values from the enclosing lexical scope, "lifting" the reference capability of the result wouldn't be safe. Some of those values could "leak" into an `iso` or `val` result, and result in data-races.
 
 ## Automatic receiver recovery
 
-When you have an `iso` or `trn` receiver, you normally can't call `ref` methods 
-on it. That's because the receiver is also an argument to a method, which means 
-both the method body and the caller have access to the receiver at the same 
-time. And _that_ means we have to alias the receiver when we call a method on 
-it. The alias of an `iso` is a `tag` (which isn't a subtype of `ref`) and the 
-alias of a `trn` is a `box` (also not a subtype of `ref`).
+When you have an `iso` or `trn` receiver, you normally can't call `ref` methods on it. That's because the receiver is also an argument to a method, which means both the method body and the caller have access to the receiver at the same time. And _that_ means we have to alias the receiver when we call a method on it. The alias of an `iso` is a `tag` (which isn't a subtype of `ref`) and the alias of a `trn` is a `box` (also not a subtype of `ref`).
 
-But we can get around this! If all the arguments to the method _at the 
-call-site_ are __sendable__, and the return type of the method is either 
-__sendable__ or isn't used _at the call-site_, then we can "automatically 
-recover" the receiver. That just means we don't have to alias the receiver - 
-and _that_ means we can call `ref` methods on an `iso` or `trn`, since `iso` 
-and `trn` are both subtypes of `ref`.
+But we can get around this! If all the arguments to the method _at the call-site_ are __sendable__, and the return type of the method is either __sendable__ or isn't used _at the call-site_, then we can "automatically recover" the receiver. That just means we don't have to alias the receiver - and _that_ means we can call `ref` methods on an `iso` or `trn`, since `iso` and `trn` are both subtypes of `ref`.
 
-Notice that this technique looks mostly at the call-site, rather than at the 
-definition of the method being called. That makes it more flexible. For 
-example, if the method being called wants a `ref` argument, and we pass it an 
-`iso` argument, that's __sendable__ at the call-site, so we can still do 
-automatic receiver recovery.
+Notice that this technique looks mostly at the call-site, rather than at the definition of the method being called. That makes it more flexible. For example, if the method being called wants a `ref` argument, and we pass it an `iso` argument, that's __sendable__ at the call-site, so we can still do automatic receiver recovery.
 
-This may sound a little complicated, but in practice it means you can write 
-code that treats an `iso` mostly like a `ref`, and the compiler will complain 
-when it's wrong. For example:
+This may sound a little complicated, but in practice it means you can write code that treats an `iso` mostly like a `ref`, and the compiler will complain when it's wrong. For example:
 
 ```pony
 let s = recover String end
 s.append("hi")
 ```
 
-Here, we create a `String iso` and then append some text to it. The append 
-method takes a `ref` receiver and a `box` parameter. We can automatically 
-recover the `iso` receiver, since we pass a `val` parameter, so everything is 
-fine.
+Here, we create a `String iso` and then append some text to it. The append method takes a `ref` receiver and a `box` parameter. We can automatically recover the `iso` receiver, since we pass a `val` parameter, so everything is fine.

--- a/capabilities/reference-capabilities.md
+++ b/capabilities/reference-capabilities.md
@@ -1,16 +1,12 @@
 # Reference Capabilities
 
-So if the object _is_ the capability, what controls what we can do with the 
-object? How do we express our _access rights_ on that object?
+So if the object _is_ the capability, what controls what we can do with the object? How do we express our _access rights_ on that object?
 
 In Pony, we do it with _reference capabilities_.
 
 ## Rights are part of a capability
 
-If you open a file in UNIX, and get a file descriptor back, that file 
-descriptor is token that designates an object - but it isn't a capability. To 
-be a capability, we need to open that file with some permission - some access 
-right. For example:
+If you open a file in UNIX, and get a file descriptor back, that file descriptor is token that designates an object - but it isn't a capability. To be a capability, we need to open that file with some permission - some access right. For example:
 
 ```C
 int fd = open("/etc/passwd", O_RDWR);
@@ -18,133 +14,66 @@ int fd = open("/etc/passwd", O_RDWR);
 
 Now we have a token, and a set of rights.
 
-In Pony, every reference has both a type and a reference capability. In fact, 
-the reference capability is _part_ of its type. These allow you to specify 
-which of your objects can be shared with other actors and allow the compiler to 
-check that what you're doing is concurrency safe.
+In Pony, every reference has both a type and a reference capability. In fact, the reference capability is _part_ of its type. These allow you to specify which of your objects can be shared with other actors and allow the compiler to check that what you're doing is concurrency safe.
 
 ## Basic concepts
 
-There are a few simple concepts you need to understand before reference 
-capabilities will make any sense. We've talked about some of these already, and 
-some may already be obvious to you, but it's worth recapping here.
+There are a few simple concepts you need to understand before reference capabilities will make any sense. We've talked about some of these already, and some may already be obvious to you, but it's worth recapping here.
 
 __Shared mutable data is hard__
 
-The problem with concurrency is shared mutable data. If two different threads 
-have access to the same piece of data then they might try to update it at the 
-same time. At best this can lead to the two threads having different versions 
-of the data. At worst the updates can interact badly resulting in the data 
-being overwritten with garbage. The standard way to avoid these problems is to 
-use locks to prevent data updates from happening at the same time. This causes 
-big performance hits and is very difficult to get right, so it causes lots of 
-bugs.
+The problem with concurrency is shared mutable data. If two different threads have access to the same piece of data then they might try to update it at the same time. At best this can lead to the two threads having different versions of the data. At worst the updates can interact badly resulting in the data being overwritten with garbage. The standard way to avoid these problems is to use locks to prevent data updates from happening at the same time. This causes big performance hits and is very difficult to get right, so it causes lots of bugs.
 
 __Immutable data can be safely shared__
 
-Any data that is immutable (i.e. it cannot be changed) is safe to use 
-concurrently. Since it is immutable it is never updated and it's the updates 
-that cause concurrency problems.
+Any data that is immutable (i.e. it cannot be changed) is safe to use concurrently. Since it is immutable it is never updated and it's the updates that cause concurrency problems.
 
 __Isolated data is safe__
 
-If a block of data has only one reference to it then we call it __isolated__. 
-Since there is only one reference to it, isolated data cannot be __shared__ by 
-multiple threads, so there are no concurrency problems. Isolated data can be 
-passed between multiple threads. As long as only one of them has a reference to 
-it at a time then the data is still safe from concurrency problems.
+If a block of data has only one reference to it then we call it __isolated__. Since there is only one reference to it, isolated data cannot be __shared__ by multiple threads, so there are no concurrency problems. Isolated data can be passed between multiple threads. As long as only one of them has a reference to it at a time then the data is still safe from concurrency problems.
 
 __Isolated data may be complex__
 
-An isolated piece of data may be a single byte. But it can also be a large data 
-structure with multiple references between the various objects in that 
-structure. What matters for the data to be isolated is that there is only a 
-single reference to that structure as a whole. We talk about the 
-__isolation boundary__ of a data structure. For the structure to be isolated:
+An isolated piece of data may be a single byte. But it can also be a large data structure with multiple references between the various objects in that structure. What matters for the data to be isolated is that there is only a single reference to that structure as a whole. We talk about the __isolation boundary__ of a data structure. For the structure to be isolated:
 
-1. There must only be a single reference outside the boundary that points to an 
-object inside.
-1. There can be any number of references inside the boundary, but none of them 
-must point to an object outside.
+1. There must only be a single reference outside the boundary that points to an object inside.
+1. There can be any number of references inside the boundary, but none of them must point to an object outside.
 
 __Every actor is single threaded__
 
-The code within a single actor is never run concurrently. This means that, 
-within a single actor, data updates cannot cause problems. It's only when we 
-want to share data between actors that we have problems.
+The code within a single actor is never run concurrently. This means that, within a single actor, data updates cannot cause problems. It's only when we want to share data between actors that we have problems.
 
-__OK, safely sharing data concurrently is tricky. How do reference capabilities 
-help?__
+__OK, safely sharing data concurrently is tricky. How do reference capabilities help?__
 
-By sharing only immutable data and exchanging only isolated data we can have 
-safe concurrent programs without locks. The problem is that it's very difficult 
-to do that correctly. If you accidentally hang on to a reference to some 
-isolated data you've handed over or change something you've shared as immutable 
-then everything goes wrong. What you need is for the compiler to force you to 
-live up to your promises. Pony reference capabilities allow the compiler to do 
-just that.
+By sharing only immutable data and exchanging only isolated data we can have safe concurrent programs without locks. The problem is that it's very difficult to do that correctly. If you accidentally hang on to a reference to some isolated data you've handed over or change something you've shared as immutable then everything goes wrong. What you need is for the compiler to force you to live up to your promises. Pony reference capabilities allow the compiler to do just that.
 
 ## Type qualifiers
 
-If you've used C/C++, you may be familiar with `const`, which is a _type 
-qualifier_ that tells the compiler not to allow the programmer to _mutate_ 
-something.
+If you've used C/C++, you may be familiar with `const`, which is a _type qualifier_ that tells the compiler not to allow the programmer to _mutate_ something.
 
-A reference capability is a form of _type qualifier_ and provides a lot more 
-guarantees than `const` does!
+A reference capability is a form of _type qualifier_ and provides a lot more guarantees than `const` does!
 
-In Pony, every use of a type has a reference capability. These capabilities 
-apply to variables, rather than to the type as a whole. In other words, when 
-you define a `class Wombat`, you don't pick a reference capability for it. 
-Instead, `Wombat` variables each have their own reference capability.
+In Pony, every use of a type has a reference capability. These capabilities apply to variables, rather than to the type as a whole. In other words, when you define a `class Wombat`, you don't pick a reference capability for it. Instead, `Wombat` variables each have their own reference capability.
 
-As an example, in some languages you have to define a type that represents a 
-mutable `String` and another type that represents an immutable `String`. For 
-example, in Java there is a `String` and a `StringBuilder`. In Pony, you can 
-define a single `class String` and have some variables that are `String ref` 
-(which are mutable) and other variables that are `String val` (which are 
-immutable).
+As an example, in some languages you have to define a type that represents a mutable `String` and another type that represents an immutable `String`. For example, in Java there is a `String` and a `StringBuilder`. In Pony, you can define a single `class String` and have some variables that are `String ref` (which are mutable) and other variables that are `String val` (which are immutable).
 
 ## The list of reference capabilities
 
-There are six reference capabilities in Pony and they all have strict 
-definitions and rules on how they can be used. We'll get to all of that later, 
-but for now here are their names and what you use them for:
+There are six reference capabilities in Pony and they all have strict definitions and rules on how they can be used. We'll get to all of that later, but for now here are their names and what you use them for:
 
-__Isolated__, written `iso`. This is for references to isolated data 
-structures. If you have an `iso` variable then you know that there are no other 
-variables that can access that data. So you can change it however you like and 
-give it to another actor.
+__Isolated__, written `iso`. This is for references to isolated data structures. If you have an `iso` variable then you know that there are no other variables that can access that data. So you can change it however you like and give it to another actor.
 
-__Value__, written `val`. This is for references to immutable data structures. 
-If you have a `val` variable then you know that no-one can change the data. So 
-you can read it and share it with other actors.
+__Value__, written `val`. This is for references to immutable data structures. If you have a `val` variable then you know that no-one can change the data. So you can read it and share it with other actors.
 
-__Reference__, written `ref`. This is for references to mutable data structures 
-that are not isolated, in other words "normal" data. If you have a `ref` 
-variable then you can read and write the data however you like and you can have 
-multiple variables that can access the same data. But you can't share it with 
-other actors.
+__Reference__, written `ref`. This is for references to mutable data structures that are not isolated, in other words "normal" data. If you have a `ref` variable then you can read and write the data however you like and you can have multiple variables that can access the same data. But you can't share it with other actors.
 
-__Box__. This is for references to data that is read-only to you. That data 
-might be immutable and shared with other actors or there may be other variables 
-using it in your actor that can change the data. Either way the `box` variable 
-can be used to safely read the data. This may sound a little pointless, but it 
-allows you to write code that can work for both `val` and `ref` variables, as 
-long as it doesn't write to the object.
+__Box__. This is for references to data that is read-only to you. That data might be immutable and shared with other actors or there may be other variables using it in your actor that can change the data. Either way the `box` variable can be used to safely read the data. This may sound a little pointless, but it allows you to write code that can work for both `val` and `ref` variables, as long as it doesn't write to the object.
 
-__Transition__, written `trn`. This is used for data structures that you want 
-to write to and give out read-only (`box`) variables to. You can also convert 
-the `trn` variable to a `val` variable later if you wish, which stops anyone 
-from changing the data and allows it be shared with other actors.
+__Transition__, written `trn`. This is used for data structures that you want to write to and give out read-only (`box`) variables to. You can also convert the `trn` variable to a `val` variable later if you wish, which stops anyone from changing the data and allows it be shared with other actors.
 
-__Tag__. This is for references used only for identification. You cannot read 
-or write data using a `tag` variable. But you can store and compare `tag`s to 
-check object identity and share `tag` variables with other actors.
+__Tag__. This is for references used only for identification. You cannot read or write data using a `tag` variable. But you can store and compare `tag`s to check object identity and share `tag` variables with other actors.
 
-Note that if you have a variable referring to an actor then you can send 
-messages to that actor regardless of what reference capability that variable 
-has.
+Note that if you have a variable referring to an actor then you can send messages to that actor regardless of what reference capability that variable has.
 
 ## How to write a reference capability
 
@@ -159,18 +88,12 @@ String box // A string box
 String tag // A string tag
 ```
 
-__What does it mean when a type doesn't specify a reference capability?__ It 
-means you are using the _default_ reference capability for that type, which is 
-defined along with the type. Here's an example from the standard library:
+__What does it mean when a type doesn't specify a reference capability?__ It means you are using the _default_ reference capability for that type, which is defined along with the type. Here's an example from the standard library:
 
 ```pony
 class val String
 ```
 
-When we use a `String` we usually mean a string value, so we make `val` the 
-default reference capability for `String`.
+When we use a `String` we usually mean a string value, so we make `val` the default reference capability for `String`.
 
-__So do I have to specify a reference capability when I define a type?__ Only 
-if you want to. There are sensible defaults that most types will use. These are 
-`ref` for classes, `val` for primitives (i.e. immutable references) and `tag` 
-for actors.
+__So do I have to specify a reference capability when I define a type?__ Only if you want to. There are sensible defaults that most types will use. These are `ref` for classes, `val` for primitives (i.e. immutable references) and `tag` for actors.

--- a/capabilities/trust-boundary.md
+++ b/capabilities/trust-boundary.md
@@ -1,44 +1,27 @@
 # Trust Boundary
 
-We mentioned previously that the C FFI can be used to break pretty much every 
-guarantee that Pony makes. This is because, once you've called into C, you are 
-executing arbitrary machine code that can stomp memory addresses, write to 
-anything, and generally be pretty badly behaved.
+We mentioned previously that the C FFI can be used to break pretty much every guarantee that Pony makes. This is because, once you've called into C, you are executing arbitrary machine code that can stomp memory addresses, write to anything, and generally be pretty badly behaved.
 
 ## Trust boundaries
 
-When we talk about trust, we don't mean things you trust because you think they 
-are perfect. Instead, we mean things you _have_ to trust in order to get things 
-done, even though you know they are _imperfect_.
+When we talk about trust, we don't mean things you trust because you think they are perfect. Instead, we mean things you _have_ to trust in order to get things done, even though you know they are _imperfect_.
 
-In Pony, when you use the C FFI, you are basically declaring that you trust the 
-C code that's being executed. That's fine, because you may need it to get work 
-done. But what about trusting someone else's code to use the C FFI? You may 
-need to, but you definitely want to know that it's happening.
+In Pony, when you use the C FFI, you are basically declaring that you trust the C code that's being executed. That's fine, because you may need it to get work done. But what about trusting someone else's code to use the C FFI? You may need to, but you definitely want to know that it's happening.
 
 ## Safe packages
 
-The normal way to handle that is to be sure you're using just the code you need 
-to use in your program. Pretty simple! Don't use some random package off the 
-internet without looking at the code and making sure it doesn't do nasty FFI 
-stuff.
+The normal way to handle that is to be sure you're using just the code you need to use in your program. Pretty simple! Don't use some random package off the internet without looking at the code and making sure it doesn't do nasty FFI stuff.
 
 But we can do better than that.
 
-In Pony, you can optionally declare a set of _safe_ packages on the `ponyc` 
-command line, like this:
+In Pony, you can optionally declare a set of _safe_ packages on the `ponyc` command line, like this:
 
 ```sh
 ponyc --safe=files:net:net/ssl my_project
 ```
 
-Here, we are declaring that only the `files`, `net` and `net/ssl` packages are 
-allowed to use C FFI calls. We've established our trust boundary: any other 
-packages that try to use C FFI calls will result in a compile-time error.
+Here, we are declaring that only the `files`, `net` and `net/ssl` packages are allowed to use C FFI calls. We've established our trust boundary: any other packages that try to use C FFI calls will result in a compile-time error.
 
 ## Example of use
 
-On the [Pony sandbox](http://sandbox.ponylang.org), we are compiling and 
-executing arbitrary code that users input. That could be dangerous. So we limit 
-the use of the C FFI to the `time` package. We don't allow access to the file 
-system, or to the network, or anything else dangerous.
+On the [Pony sandbox](http://sandbox.ponylang.org), we are compiling and executing arbitrary code that users input. That could be dangerous. So we limit the use of the C FFI to the `time` package. We don't allow access to the file system, or to the network, or anything else dangerous.

--- a/docs/types/delegates.md
+++ b/docs/types/delegates.md
@@ -1,10 +1,8 @@
-Like some other object-oriented languages, Pony has __delegates__. That is, 
-some types serve as __mixins__ that other types can use.
+Like some other object-oriented languages, Pony has __delegates__. That is, some types serve as __mixins__ that other types can use.
 
 # Delegates
 
-Any __trait__ or __interface__ can be used as a _mixin_ by exploiting delegate 
-type declarations.
+Any __trait__ or __interface__ can be used as a _mixin_ by exploiting delegate type declarations.
 
 ```pony
 trait Wombat
@@ -18,22 +16,15 @@ actor Main is Wombat
 
   new create(env : Env) =>
     env.out.print("Battle cry: " + battle_call())
-```  
+```
 
-In this example, we have defined a trait named `Wombat` with a function 
-`battle_call` that returns a `String` value. A __trait__ looks a bit like a
-__class__ but it can't have  any fields. It can however have a default
-implementation such as it does in this case.
+In this example, we have defined a trait named `Wombat` with a function `battle_call` that returns a `String` value. A __trait__ looks a bit like a __class__ but it can't have  any fields. It can however have a default implementation such as it does in this case.
 
-The class `SimpleWombat` supports this trait and the actor `Main`, also 
-supports the `Wombat` trait. The actor `Main` delegates its __Wombat__ness to
-the `SimpleWombat`  class, which provides a default implementation of
-`battle_call`.
+The class `SimpleWombat` supports this trait and the actor `Main`, also supports the `Wombat` trait. The actor `Main` delegates its __Wombat__ness to the `SimpleWombat`  class, which provides a default implementation of `battle_call`.
 
 # Overrides
 
-We can, of course, override this default behaviour simply by providing our own 
-implementation of the `battle_call` function ourselves, as below:
+We can, of course, override this default behaviour simply by providing our own implementation of the `battle_call` function ourselves, as below:
 
 ```pony
 class KungFuWombat is Wombat
@@ -51,8 +42,7 @@ actor Main is Wombat
     env.out.print("Battle cry: " + battle_call())
 ```
 
-However, now that we have two choices of Wombat, we can tune the type 
-declaration to allow more flexibility at runtime:
+However, now that we have two choices of Wombat, we can tune the type declaration to allow more flexibility at runtime:
 
 ```pony
 use "time"
@@ -72,9 +62,7 @@ actor Main is Wombat
 
 ## Disambiguation
 
-Above, we don't know what kind of `Wombat` we're going to get. But we know 
-we're going to get either a `KungFuWombat` or a `SimpleWombat`. Sometimes
-though, things get a little more complicated in real code:
+Above, we don't know what kind of `Wombat` we're going to get. But we know we're going to get either a `KungFuWombat` or a `SimpleWombat`. Sometimes though, things get a little more complicated in real code:
 
 ```pony
 trait Drone
@@ -86,10 +74,7 @@ class DroneWombat is ( Drone & Wombat)
     "Beep boop Huzzah!"
 ```
 
-Here, even though both `Drone` and `Wombat` provide function `battle_call` we 
-explicitly disambiguate that a `DroneWombat`'s battle call, is like a mechanized
-`SimpleWombat`. So we can use our `DroneWombat` just like a `Drone` or a
-`Wombat`.
+Here, even though both `Drone` and `Wombat` provide function `battle_call` we explicitly disambiguate that a `DroneWombat`'s battle call, is like a mechanized `SimpleWombat`. So we can use our `DroneWombat` just like a `Drone` or a `Wombat`.
 
 ```pony
 actor Main is Wombat
@@ -101,8 +86,8 @@ actor Main is Wombat
 
 Sometimes though, we won't be so lucky:
 
-```shell
-/WombatWars/troops.pony:26:1: clashing delegates for method battle_call, local 
+```
+/WombatWars/troops.pony:26:1: clashing delegates for method battle_call, local
 disambiguation required
 actor Main is Wombat
 ^
@@ -115,8 +100,7 @@ actor Main is Wombat
 [Finished in 0.2s with exit code 255]
 ```
 
-What just happened? Our main actor has two battle_call functions available and
-cannot unambiguously choose one. So we need to make disambiguate explicitly:
+What just happened? Our main actor has two battle_call functions available and cannot unambiguously choose one. So we need to make disambiguate explicitly:
 
 ```pony
 actor Main is Wombat
@@ -130,8 +114,7 @@ actor Main is Wombat
     "Bonzai! Beep boop! Huzzah!"
 ```
 
-We can also choose our wombat delegates based on custom logic in the 
-constructor:
+We can also choose our wombat delegates based on custom logic in the constructor:
 
 ```pony
 actor Main is Wombat
@@ -154,12 +137,6 @@ actor Main is Wombat
     "Bonzai! Beep boop! Huzzah!"
 ```
 
-Delegates are a convenient and flexible way to reuse, mixin, and/or adapt
-code to different strategies or policies allowing for a very high degree of
-flexibility in composing reasonably complex software components from relatively 
-simple parts.
+Delegates are a convenient and flexible way to reuse, mixin, and/or adapt code to different strategies or policies allowing for a very high degree of flexibility in composing reasonably complex software components from relatively simple parts.
 
-In pony, delegates can benefit from _nominal_ ( via __traits__ ) or implicit or 
-explicit _structural_ ( via __interfaces__ ) subtyping and local disambiguation 
-where necessary, whilst sensible default implementations allow for maximizing
-code reuse.
+In pony, delegates can benefit from _nominal_ ( via __traits__ ) or implicit or explicit _structural_ ( via __interfaces__ ) subtyping and local disambiguation where necessary, whilst sensible default implementations allow for maximizing code reuse.

--- a/expressions/control-structures.md
+++ b/expressions/control-structures.md
@@ -1,15 +1,10 @@
 # Control Structures
 
-To do real work in a program you have to be able to make decisions, iterate 
-through collections of items and perform actions repeatedly. For this you need 
-control structures. Pony has control structures that will be familiar to 
-programmers who have used most languages, such as `if`, `while` and `for`, but 
-in Pony they work slightly differently.
+To do real work in a program you have to be able to make decisions, iterate through collections of items and perform actions repeatedly. For this you need control structures. Pony has control structures that will be familiar to programmers who have used most languages, such as `if`, `while` and `for`, but in Pony they work slightly differently.
 
 ## Conditionals
 
-The simplest control-structure is the good old `if`. It allows you to perform 
-some action only when a condition is true. In Pony it looks like this:
+The simplest control-structure is the good old `if`. It allows you to perform some action only when a condition is true. In Pony it looks like this:
 
 ```pony
 if a > b then
@@ -17,14 +12,9 @@ if a > b then
 end
 ```
 
-__Can I use integers and pointers for the condition like I can in C?__ No. In 
-Pony `if` conditions must have type Bool, i.e. they are always true or false. 
-If you want to test whether a number `a` is not 0, then you need to explicitly 
-say `a != 0`. This restriction removes a whole category of potential bugs from 
-Pony programs.
+__Can I use integers and pointers for the condition like I can in C?__ No. In Pony `if` conditions must have type Bool, i.e. they are always true or false. If you want to test whether a number `a` is not 0, then you need to explicitly say `a != 0`. This restriction removes a whole category of potential bugs from Pony programs.
 
-If you want some alternative code for when the condition fails just add an 
-`else`:
+If you want some alternative code for when the condition fails just add an `else`:
 
 ```pony
 if a > b then
@@ -34,8 +24,7 @@ else
 end
 ```
 
-Often you want to test more than one condition in one go, giving you more than 
-two possible outcomes. You can nest `if` statements, but this quickly gets ugly:
+Often you want to test more than one condition in one go, giving you more than two possible outcomes. You can nest `if` statements, but this quickly gets ugly:
 
 ```pony
 if a == b then
@@ -49,9 +38,7 @@ else
 end
 ```
 
-As an alternative Pony provides the `elseif` keyword that combines an `else` 
-and an `if`. This works the same as saying `else if` in other languages and you 
-can have as many `elseif`s as you like for each `if`.
+As an alternative Pony provides the `elseif` keyword that combines an `else` and an `if`. This works the same as saying `else if` in other languages and you can have as many `elseif`s as you like for each `if`.
 
 ```pony
 if a == b then
@@ -63,9 +50,7 @@ else
 end
 ```
 
-__Why can't I just say "else if" like I do in C? Why the extra keyword?__ The 
-relationship between `if` and `else` in C, and other similar languages, is 
-ambiguous. For example:
+__Why can't I just say "else if" like I do in C? Why the extra keyword?__ The relationship between `if` and `else` in C, and other similar languages, is ambiguous. For example:
 
 ```C
 // C code
@@ -75,21 +60,13 @@ if(a)
 else
   printf("not a\n");
 ```
-Here it is not obvious whether the `else` is an alternative to the first or the 
-second `if`. In fact here the `else` relates to the `if(b)` so our example 
-contains a bug. Pony avoids this type of bug by handling `if` and `else` 
-differently and the need for `elseif` comes out of that.
+Here it is not obvious whether the `else` is an alternative to the first or the second `if`. In fact here the `else` relates to the `if(b)` so our example contains a bug. Pony avoids this type of bug by handling `if` and `else` differently and the need for `elseif` comes out of that.
 
 ## Everything is an expression
 
-The big difference for control structures between Pony and other languages is 
-that in Pony everything is an expression. In languages like C++ and Java `if` 
-is a statement, not an expression. This means that you can't have an `if` 
-inside an expression, there has to be a separate conditional operator '?'.
+The big difference for control structures between Pony and other languages is that in Pony everything is an expression. In languages like C++ and Java `if` is a statement, not an expression. This means that you can't have an `if` inside an expression, there has to be a separate conditional operator '?'.
 
-In Pony there are no statements there are only expressions, everything hands 
-back a value. Your `if` statement hands you back a value. Your `for` loop 
-(which we'll get to a bit later) hands you back a value. 
+In Pony there are no statements there are only expressions, everything hands back a value. Your `if` statement hands you back a value. Your `for` loop (which we'll get to a bit later) hands you back a value.
 
 This means you can use `if` directly in a calculation:
 
@@ -97,11 +74,9 @@ This means you can use `if` directly in a calculation:
 x = 1 + if lots then 100 else 2 end
 ```
 
-This will give __x__ a value of either 3 or 101, depending on the variable 
-__lots__.
+This will give __x__ a value of either 3 or 101, depending on the variable __lots__.
 
-If the `then` and `else` branches of an `if` produce different types then the 
-`if` produces a __union__ of the two.
+If the `then` and `else` branches of an `if` produce different types then the `if` produces a __union__ of the two.
 
 ```pony
 var x: (String | Bool) =
@@ -112,8 +87,7 @@ var x: (String | Bool) =
   end
 ```
 
-__But what if my if doesn't have an else?__ Any `else` branch that doesn't 
-exist gives an implicit `None`.
+__But what if my if doesn't have an else?__ Any `else` branch that doesn't exist gives an implicit `None`.
 
 ```pony
 var x: (String | None) =
@@ -122,19 +96,15 @@ var x: (String | None) =
   end
 ```
 
-__Does Pony still have the conditional operator "?"?__ No, it's not needed. 
-Just use `if`.
+__Does Pony still have the conditional operator "?"?__ No, it's not needed. Just use `if`.
 
 ## Loops
 
-`if` allows you to choose what to do, but to do something more than once you 
-want a loop.
+`if` allows you to choose what to do, but to do something more than once you want a loop.
 
 ### While
 
-Pony `while` loops are very similar to those in other languages. A condition 
-expression is evaluated and if it's true we execute the code inside the loop. 
-When we're done we evaluate the condition again and keep going until it's false.
+Pony `while` loops are very similar to those in other languages. A condition expression is evaluated and if it's true we execute the code inside the loop. When we're done we evaluate the condition again and keep going until it's false.
 
 Here's an example that prints out the numbers 1 to 10:
 
@@ -147,37 +117,19 @@ while count <= 10 do
 end
 ```
 
-Just like `if` expressions `while` is also an expression. The value returned is 
-just the value of the expression inside the loop the last time we go round it. 
-For this example that will be the value given by `count = count + 1` when count 
-is incremented to 11. Since Pony assignments hand back the _old_ value our 
-`while` loop will return 10.
+Just like `if` expressions `while` is also an expression. The value returned is just the value of the expression inside the loop the last time we go round it. For this example that will be the value given by `count = count + 1` when count is incremented to 11. Since Pony assignments hand back the _old_ value our `while` loop will return 10.
 
-__But what if the condition evaluates to false the first time we try, then we 
-don't go round the loop at all?__ In Pony `while` expressions can also have an 
-`else` block. In general, Pony `else` blocks provide a value when the 
-expression they are attached to doesn't. A `while` doesn't have a value to give 
-if the condition evaluates to false the first time, so the `else` provides it 
-instead.
+__But what if the condition evaluates to false the first time we try, then we don't go round the loop at all?__ In Pony `while` expressions can also have an `else` block. In general, Pony `else` blocks provide a value when the expression they are attached to doesn't. A `while` doesn't have a value to give if the condition evaluates to false the first time, so the `else` provides it instead.
 
-__So is this like an else block on a while loop in Python?__ No, this is very 
-different. In Python the `else` is run when the `while` completes. In Pony the 
-`else` is only run when the expression in the `while` isn't.
+__So is this like an else block on a while loop in Python?__ No, this is very different. In Python the `else` is run when the `while` completes. In Pony the `else` is only run when the expression in the `while` isn't.
 
 ### Break
 
-Sometimes you want to stop part-way through a loop and give up altogether. Pony 
-has the `break` keyword for this and it is very similar to its counterpart in 
-languages like C++, C# and Python.
+Sometimes you want to stop part-way through a loop and give up altogether. Pony has the `break` keyword for this and it is very similar to its counterpart in languages like C++, C# and Python.
 
-`break` immediately exits from the innermost loop it's in. Since the loop has 
-to return a value `break` can take an expression. This is optional and if it's 
-missed out a value of `None` is returned.
+`break` immediately exits from the innermost loop it's in. Since the loop has to return a value `break` can take an expression. This is optional and if it's missed out a value of `None` is returned.
 
-Let's have an example. Suppose you want to go through a list of names you're 
-getting from somewhere, looking for either "Jack" or "Jill". If neither of 
-those appear you'll just take the last name you're given and if you're not 
-given any names at all you'll use "Herbert".
+Let's have an example. Suppose you want to go through a list of names you're getting from somewhere, looking for either "Jack" or "Jill". If neither of those appear you'll just take the last name you're given and if you're not given any names at all you'll use "Herbert".
 
 ```pony
 var name =
@@ -192,46 +144,29 @@ var name =
   end
 ```
 
-So first we ask if there are any more names to get. If there are then we get a 
-name and see if it's "Jack" or "Jill". If it is we're done and we break out of 
-the loop, handing back the name we've found. If not we try again.
+So first we ask if there are any more names to get. If there are then we get a name and see if it's "Jack" or "Jill". If it is we're done and we break out of the loop, handing back the name we've found. If not we try again.
 
-The line `name'` appears at the end of the loop so that will be our value 
-returned from the last iteration, if neither "Jack" nor "Jill" is found.
+The line `name'` appears at the end of the loop so that will be our value returned from the last iteration, if neither "Jack" nor "Jill" is found.
 
-The `else` block provides our value of "Herbert" if there are no names 
-available at all.
+The `else` block provides our value of "Herbert" if there are no names available at all.
 
-__Can I break out of multiple, nested loops like the Java labelled break?__ No, 
-Pony does not support that. If you need to break out of multiple loops you 
-should probably refactor your code or use a worker function.
+__Can I break out of multiple, nested loops like the Java labelled break?__ No, Pony does not support that. If you need to break out of multiple loops you should probably refactor your code or use a worker function.
 
 ### Continue
 
-Sometimes you want to stop part-way through one loop iteration and move onto 
-the next. Like other languages Pony uses the `continue` keyword for this.
+Sometimes you want to stop part-way through one loop iteration and move onto the next. Like other languages Pony uses the `continue` keyword for this.
 
-`continue` stops executing the current iteration of the innermost loop it's in 
-and evaluates the condition ready for the next iteration.
+`continue` stops executing the current iteration of the innermost loop it's in and evaluates the condition ready for the next iteration.
 
-If `continue` is executed during the last iteration of the loop then we have no 
-value to return from the loop. In this case we use the loop's `else` expression 
-to get a value. As with the `if` expression if no `else` expression is provided 
-`None` is returned.
+If `continue` is executed during the last iteration of the loop then we have no value to return from the loop. In this case we use the loop's `else` expression to get a value. As with the `if` expression if no `else` expression is provided `None` is returned.
 
-__Can I continue an outer, nested loop like the Java labelled continue?__ No, 
-Pony does not support that. If you need to continue an outer loop you should 
-probably refactor your code.
+__Can I continue an outer, nested loop like the Java labelled continue?__ No, Pony does not support that. If you need to continue an outer loop you should probably refactor your code.
 
 ### For
 
-For iterating over a collection of items Pony uses the `for` keyword. This is 
-very similar to `foreach` in C#, `for`..`in` in Python and `for` in Java when 
-used with a collection. It is very different to `for` in C and C++.
+For iterating over a collection of items Pony uses the `for` keyword. This is very similar to `foreach` in C#, `for`..`in` in Python and `for` in Java when used with a collection. It is very different to `for` in C and C++.
 
-The Pony `for` loop iterates over a collection of items using an iterator. On 
-each iteration round the loop we ask the iterator if there are any more 
-elements to process and if there are we ask it for the next one.
+The Pony `for` loop iterates over a collection of items using an iterator. On each iteration round the loop we ask the iterator if there are any more elements to process and if there are we ask it for the next one.
 
 For example to print out all the strings in an array:
 
@@ -241,22 +176,15 @@ for name in ["Bob", "Fred", "Sarah"].values() do
 end
 ```
 
-Note the call to `values()` on the array, this is because the loop needs an 
-iterator not an array.
+Note the call to `values()` on the array, this is because the loop needs an iterator not an array.
 
-The iterator does not have to be of any particular type, but needs to provide 
-the following methods:
+The iterator does not have to be of any particular type, but needs to provide the following methods:
 ```pony
   fun has_next(): Bool
   fun next(): T?
 ```
 
-where T is the type of the objects in the collection. You don't need to worry 
-about this unless you're writing your own iterators. To use existing 
-collections, such as those provided in the standard library, you can just use 
-`for` and it will all work. If you do write your own iterators note that we use 
-structural typing, so your iterator doesn't need to declare that it provides 
-any particular type.
+where T is the type of the objects in the collection. You don't need to worry about this unless you're writing your own iterators. To use existing collections, such as those provided in the standard library, you can just use `for` and it will all work. If you do write your own iterators note that we use structural typing, so your iterator doesn't need to declare that it provides any particular type.
 
 You can think of the above example as being equivalent to:
 
@@ -268,32 +196,22 @@ while iterator.has_next() do
 end
 ```
 
-Note that the variable __name__ is declared _let_, you cannot assign to the 
-control variable within the loop.
+Note that the variable __name__ is declared _let_, you cannot assign to the control variable within the loop.
 
-__Can I use break and continue with for loops?__ Yes, `for` loops can have 
-`else` expressions attached and can use `break` and `continue` just as for 
-`while`.
+__Can I use break and continue with for loops?__ Yes, `for` loops can have `else` expressions attached and can use `break` and `continue` just as for `while`.
 
 ### Repeat
 
-The final loop construct that Pony provides is `repeat` `until`. Here we 
-evaluate the expression in the loop and then evaluate a condition expression 
-to see if we're done or we should go round again.
+The final loop construct that Pony provides is `repeat` `until`. Here we evaluate the expression in the loop and then evaluate a condition expression to see if we're done or we should go round again.
 
-This is similar to `do` `while` in C++, C# and Java except that the termination 
-condition is reversed, i.e. those languages terminate the loop when the 
-condition expression is false, Pony terminates the loop when the condition 
-expression is true.
+This is similar to `do` `while` in C++, C# and Java except that the termination condition is reversed, i.e. those languages terminate the loop when the condition expression is false, Pony terminates the loop when the condition expression is true.
 
 The differences between `while` and `repeat` in Pony are:
 
-1. We always go round the loop at least once with `repeat`, whereas with 
-`while` we may not go round at all.
+1. We always go round the loop at least once with `repeat`, whereas with `while` we may not go round at all.
 1. The termination condition is reversed.
 
-Suppose we're trying to create something and we want to keep trying until it's 
-good enough:
+Suppose we're trying to create something and we want to keep trying until it's good enough:
 
 ```pony
 repeat
@@ -301,11 +219,6 @@ repeat
 until present.marksOutOfTen() > 7 end
 ```
 
-Just like `while` loops the value given by a `repeat` loop is the value of the 
-expression within the loop on the last iteration and `break` and `continue` can 
-be used.
+Just like `while` loops the value given by a `repeat` loop is the value of the expression within the loop on the last iteration and `break` and `continue` can be used.
 
-__Since you always go round a repeat loop at least once do you ever need to 
-give it an else expression?__ Yes you may need to. A `continue` in the last 
-iteration of a `repeat` loop needs to get a value from somewhere and an `else` 
-expression is used for that.
+__Since you always go round a repeat loop at least once do you ever need to give it an else expression?__ Yes you may need to. A `continue` in the last iteration of a `repeat` loop needs to get a value from somewhere and an `else` expression is used for that.

--- a/expressions/exceptions.md
+++ b/expressions/exceptions.md
@@ -1,15 +1,10 @@
 # Exceptions
 
-Pony provides a simple exception mechanism to aid error handling. At any point 
-the code may decide to declare an `error` has occured. Code execution halts at 
-that point and the call chain is unwound until the nearest enclosing error 
-handler is found. This is all checked at compile time so errors cannot cause 
-the whole program to crash.
+Pony provides a simple exception mechanism to aid error handling. At any point the code may decide to declare an `error` has occured. Code execution halts at that point and the call chain is unwound until the nearest enclosing error handler is found. This is all checked at compile time so errors cannot cause the whole program to crash.
 
 ## Raising and handling errors
 
-An error is raised with the command `error`. Error handlers are declared using 
-the try-else syntax.
+An error is raised with the command `error`. Error handlers are declared using the try-else syntax.
 
 ```pony
 try
@@ -21,24 +16,15 @@ else
 end
 ```
 
-In the above code callA() will always be executed and so will callB(). If the 
-result of callB() is true then we will proceed to callC() in the normal fashion 
-and callD() will not then be executed.
+In the above code callA() will always be executed and so will callB(). If the result of callB() is true then we will proceed to callC() in the normal fashion and callD() will not then be executed.
 
-However, if callB() returns false, then an error will be raised. At this point 
-execution will stop and the nearest enclosing error handler will be found and 
-executed. In this example that is our else block and so callD() will be 
-executed.
+However, if callB() returns false, then an error will be raised. At this point execution will stop and the nearest enclosing error handler will be found and executed. In this example that is our else block and so callD() will be executed.
 
-In either case execution will then carry on with whatever code comes after the 
-try `end`.
+In either case execution will then carry on with whatever code comes after the try `end`.
 
-__Do I have to provide an error handler?__ No. The try block will handle any 
-errors regardless. If you don't provide an error handler then no error handling 
-action will be taken - execution will simply continue after the try expression.
+__Do I have to provide an error handler?__ No. The try block will handle any errors regardless. If you don't provide an error handler then no error handling action will be taken - execution will simply continue after the try expression.
 
-If you want to do something that might raise an error, but you don't care if it 
-does you can just put in it a try block without an else.
+If you want to do something that might raise an error, but you don't care if it does you can just put in it a try block without an else.
 
 ```pony
 try
@@ -46,18 +32,11 @@ try
 end
 ```
 
-__Is there anything my error handler has to do?__ No. If you provide an error 
-handler then it must contain some code, but it is entirely up to you what it 
-does.
+__Is there anything my error handler has to do?__ No. If you provide an error handler then it must contain some code, but it is entirely up to you what it does.
 
 ## Partial functions
 
-Pony does not require that all errors are handled immediately as in our 
-previous examples. Instead functions can raise errors that are handled by 
-whatever code calls them. These are called partial functions (this is a 
-mathematical term meaning a function that does not have a defined result for 
-all possible inputs, i.e. arguments). Partial functions __must__ be marked as 
-such in Pony with a `?`.
+Pony does not require that all errors are handled immediately as in our previous examples. Instead functions can raise errors that are handled by whatever code calls them. These are called partial functions (this is a mathematical term meaning a function that does not have a defined result for all possible inputs, i.e. arguments). Partial functions __must__ be marked as such in Pony with a `?`.
 
 ```pony
 fun factorial(x: I32): I32 ? =>
@@ -69,31 +48,19 @@ fun factorial(x: I32): I32 ? =>
   end
 ```
 
-Everywhere that an error can be generated in Pony (an error command, a call to 
-a partial function or certain built-in language constructs) must appear within 
-a try block or a function that is marked as partial. This is checked at compile 
-time, ensuring that an error cannot escape handling and crash the program.
+Everywhere that an error can be generated in Pony (an error command, a call to a partial function or certain built-in language constructs) must appear within a try block or a function that is marked as partial. This is checked at compile time, ensuring that an error cannot escape handling and crash the program.
 
 ## Partial constructors and behaviours
 
-Constructors may also be marked as partial. If a constructor raises an error 
-then the construction is considered to have failed and the object under 
-construction is discarded without ever being returned to the caller.
+Constructors may also be marked as partial. If a constructor raises an error then the construction is considered to have failed and the object under construction is discarded without ever being returned to the caller.
 
-When an actor constructor is called the actor is created and a reference to it 
-is returned immediately. However the constructor code is executed 
-asynchronously at some later time. If an actor constructor were to raise an 
-error it would already be too late to report this to the caller. For this 
-reason constructors for actors may not be partial.
+When an actor constructor is called the actor is created and a reference to it is returned immediately. However the constructor code is executed asynchronously at some later time. If an actor constructor were to raise an error it would already be too late to report this to the caller. For this reason constructors for actors may not be partial.
 
-Behaviours are also executed asynchronously and so cannot be partial for the 
-same reason.
+Behaviours are also executed asynchronously and so cannot be partial for the same reason.
 
 ## Try-then blocks
 
-In addition to an `else` error handler a try command can have a `then` block. 
-This is executed after the rest of the try, whether or not an error is raised 
-or handled. Expanding our example from earlier:
+In addition to an `else` error handler a try command can have a `then` block. This is executed after the rest of the try, whether or not an error is raised or handled. Expanding our example from earlier:
 
 ```pony
 try
@@ -107,24 +74,15 @@ then
 end
 ```
 
-The callE() will always be excuted. If callB() returns true then the sequence 
-executed is callA(), callB(), callC(), callE(). If callB() returns false then 
-the sequence executed is callA(), callB(), callD(), callE().
+The callE() will always be excuted. If callB() returns true then the sequence executed is callA(), callB(), callC(), callE(). If callB() returns false then the sequence executed is callA(), callB(), callD(), callE().
 
-__Do I have to have an else error handler to have a then block?__ No. You can 
-have a try-then block without an else if you like.
+__Do I have to have an else error handler to have a then block?__ No. You can have a try-then block without an else if you like.
 
-__Will my then block really always be executed, even if I return inside the 
-try?__ Yes, your `then` expression will __always__ be executed when the try 
-block is complete. The only way it won't be is if the try never completes (due 
-to an infinite loop), the machine is powered off or the process is killed (and 
-then, maybe).
+__Will my then block really always be executed, even if I return inside the try?__ Yes, your `then` expression will __always__ be executed when the try block is complete. The only way it won't be is if the try never completes (due to an infinite loop), the machine is powered off or the process is killed (and then, maybe).
 
 ## With blocks
 
-A `with` expression can be used to ensure disposal of an object when it is no 
-longer needed. A common case is a database connection which needs to be closed 
-after use to avoid resource leaks on the server. For example:
+A `with` expression can be used to ensure disposal of an object when it is no longer needed. A common case is a database connection which needs to be closed after use to avoid resource leaks on the server. For example:
 
 ```pony
 with obj = SomeObjectThatNeedsDisposing() do
@@ -132,10 +90,7 @@ with obj = SomeObjectThatNeedsDisposing() do
 end
 ```
 
-`obj.dispose()` will be called whether the code inside the `with` block 
-completes successfully or raises an error. To take part in a `with` expression, 
-the object that needs resource clean-up must therefore provide a `dispose()` 
-method:
+`obj.dispose()` will be called whether the code inside the `with` block completes successfully or raises an error. To take part in a `with` expression, the object that needs resource clean-up must therefore provide a `dispose()` method:
 
 ```pony
 class SomeObjectThatNeedsDisposing
@@ -163,34 +118,18 @@ with obj = SomeObjectThatNeedsDisposing(), other = SomeOtherDisposableObject() d
 end
 ```
 
-The value of a `with` expression is the value of the last expression in the 
-block, or of the last expression in the `else` block, if there is one and an 
-error occurred.
+The value of a `with` expression is the value of the last expression in the block, or of the last expression in the `else` block, if there is one and an error occurred.
 
 ## Language constructs that can raise errors
 
-The only language construct that can raise an error, other than the error 
-command or calling a partial method, is the `as` command. This converts the 
-given value to the specified type, if it can be. If it can't then an error is 
-raised. This means that the `as` command can only be used inside a try block or 
-a partial method.
+The only language construct that can raise an error, other than the error command or calling a partial method, is the `as` command. This converts the given value to the specified type, if it can be. If it can't then an error is raised. This means that the `as` command can only be used inside a try block or a partial method.
 
 ## Comparison to exceptions in other languages
 
-Pony exceptions behave very much the same as those in C++, Java, C#, Python and 
-Ruby. The key difference is that Pony exceptions do not have a type or instance 
-associated with them. This makes them the same as C++ exceptions would be if a 
-fixed literal was always thrown, eg `throw 3;`. This difference simplifies 
-exception handling for the programmer and allows for much better runtime error 
-handling performance.
+Pony exceptions behave very much the same as those in C++, Java, C#, Python and Ruby. The key difference is that Pony exceptions do not have a type or instance associated with them. This makes them the same as C++ exceptions would be if a fixed literal was always thrown, eg `throw 3;`. This difference simplifies exception handling for the programmer and allows for much better runtime error handling performance.
 
-The `else` handler in a `try` expression is just like a `catch(...)` in C++, 
-`catch(Exception e)` in Java or C#, `except:` in Python or `rescue` in Ruby. 
-Since exceptions do not have types there is no need for handlers to specify 
-types or to have multiple handlers in a single try block.
+The `else` handler in a `try` expression is just like a `catch(...)` in C++, `catch(Exception e)` in Java or C#, `except:` in Python or `rescue` in Ruby. Since exceptions do not have types there is no need for handlers to specify types or to have multiple handlers in a single try block.
 
-The `then` block in a `try` expression is just like a `finally` in Java, C# or 
-Python and `ensure` in Ruby.
+The `then` block in a `try` expression is just like a `finally` in Java, C# or Python and `ensure` in Ruby.
 
-If required, error handlers can "reraise" by using the `error` command within 
-the handler.
+If required, error handlers can "reraise" by using the `error` command within the handler.

--- a/expressions/index.md
+++ b/expressions/index.md
@@ -1,4 +1,3 @@
 # Chapter 3: Expressions
 
-This chapter covers the various expressions that make up Pony. From variables to
-control structures and more.
+This chapter covers the various expressions that make up Pony. From variables to control structures and more.

--- a/expressions/infix-ops.md
+++ b/expressions/infix-ops.md
@@ -1,7 +1,6 @@
 # Infix Operators
 
-Infix operators take two operands and are written between those operands. 
-Arithmetic and comparison operators are the most common:
+Infix operators take two operands and are written between those operands. Arithmetic and comparison operators are the most common:
 
 ```pony
 1 + 2
@@ -12,26 +11,17 @@ Pony has pretty much the same set of infix operators as other languages.
 
 ## Precedence
 
-When using infix operators in complex expressions a key question is the 
-__precedence__, i.e. which operator is evaluated first. Given this expression:
+When using infix operators in complex expressions a key question is the __precedence__, i.e. which operator is evaluated first. Given this expression:
 
 ```pony
 1 + 2 * 3
 ```
 
-We will get a value of 9 if we evaluate the addition first and 7 if we evaluate 
-the multiplication first. In mathematics there are rules about the order in 
-which to evaluate operators and most programming languages follow this approach.
+We will get a value of 9 if we evaluate the addition first and 7 if we evaluate the multiplication first. In mathematics there are rules about the order in which to evaluate operators and most programming languages follow this approach.
 
-The problem with this is that the programmer has to remember the order and 
-people aren't very good at things like that. Most people will remember to do 
-multiplication before addition, but what about left bit shifting versus bitwise 
-and? Sometimes people misremember (or guess wrong) and that leads to bugs. 
-Worse, those bugs are often very hard to spot.
+The problem with this is that the programmer has to remember the order and people aren't very good at things like that. Most people will remember to do multiplication before addition, but what about left bit shifting versus bitwise and? Sometimes people misremember (or guess wrong) and that leads to bugs. Worse, those bugs are often very hard to spot.
 
-Pony takes a different approach and outlaws infix precedence. Any expression 
-where more than one infix operator is used __must__ use parentheses to remove 
-the ambiguity. If you fail to do this the compiler will complain.
+Pony takes a different approach and outlaws infix precedence. Any expression where more than one infix operator is used __must__ use parentheses to remove the ambiguity. If you fail to do this the compiler will complain.
 
 This means that the example above is illegal in Pony and should be rewritten as:
 
@@ -47,33 +37,25 @@ Repeated use of a single operator however is fine:
 
 ## Operator aliasing
 
-Most infix operators in Pony are actually aliases for functions. The left 
-operand is the receiver the function is called on and the right operand is 
-passed as an argument. For example the following expressions are equivalent:
+Most infix operators in Pony are actually aliases for functions. The left operand is the receiver the function is called on and the right operand is passed as an argument. For example the following expressions are equivalent:
 
 ```pony
 x + y
 x.add(y)
 ```
 
-This means that `+` is not a special symbol that can only be applied to magic 
-types. Any type can provide its own `add` function and the programmer can then 
-use `+` with that type, if they want to.
+This means that `+` is not a special symbol that can only be applied to magic types. Any type can provide its own `add` function and the programmer can then use `+` with that type, if they want to.
 
-When defining your own `add` function there is no restriction on the types of 
-the parameter or the return type. The right side of the `+` will have to match 
-the parameter type and the whole `+` expression will have the type that `add` 
-returns.
+When defining your own `add` function there is no restriction on the types of the parameter or the return type. The right side of the `+` will have to match the parameter type and the whole `+` expression will have the type that `add` returns.
 
-Here's a full example for defining a type which allows use of `+`. This is all 
-you need:
+Here's a full example for defining a type which allows use of `+`. This is all you need:
 
 ```pony
 // Define a suitable type
 class Pair
   var _x: U32 = 0
   var _y: U32 = 0
-  
+
   new create(x: U32, y: U32) =>
     _x = x
 	_y = y
@@ -90,15 +72,9 @@ class Foo
 	var z = x + y
 ```
 
-Since Pony does not allow overloading of functions by argument type, each type 
-can only have a single `add` function. It is possible to overload infix 
-operators to some degree using union types or f-bounded polymorphism, but this 
-is beyond the scope of this tutorial. See the Pony standard library for further 
-information.
+Since Pony does not allow overloading of functions by argument type, each type can only have a single `add` function. It is possible to overload infix operators to some degree using union types or f-bounded polymorphism, but this is beyond the scope of this tutorial. See the Pony standard library for further information.
 
-You do not have to worry about any of this if you don't want to. You can simply 
-use the existing infix operators for numbers just like any other language and 
-not provide them for your own types.
+You do not have to worry about any of this if you don't want to. You can simply use the existing infix operators for numbers just like any other language and not provide them for your own types.
 
 The full list of infix operators that are aliases for functions is:
 
@@ -127,23 +103,17 @@ xor      | op_xor() | Xor, both bitwise and logical
 
 ## Short circuiting
 
-The `and` and `or` operators use __short circuiting__ when used with Bool 
-variables. This means that the first operand is always evaluated, but the 
-second is only evaluated if it can affect the result.
+The `and` and `or` operators use __short circuiting__ when used with Bool variables. This means that the first operand is always evaluated, but the second is only evaluated if it can affect the result.
 
-For `and`, if the first operand is __false__ then the second operand is not 
-evaluated, since it cannot affect the result.
+For `and`, if the first operand is __false__ then the second operand is not evaluated, since it cannot affect the result.
 
-For `or`, if the first operand is __true__ then the second operand is not 
-evaluated, since it cannot affect the result.
+For `or`, if the first operand is __true__ then the second operand is not evaluated, since it cannot affect the result.
 
-This is a special feature built into the compiler, it cannot be used with 
-operator aliasing for any other type.
+This is a special feature built into the compiler, it cannot be used with operator aliasing for any other type.
 
 ## Unary operators
 
-The unary operators are handled in the same manner, but with only one operand. 
-For example the following expressions are equivalent:
+The unary operators are handled in the same manner, but with only one operand. For example the following expressions are equivalent:
 
 ```pony
 -x

--- a/expressions/methods.md
+++ b/expressions/methods.md
@@ -1,20 +1,14 @@
 # Methods
 
-All Pony code that actually does something, rather than defining types etc, 
-appears in named blocks which are referred to as methods. There are three kinds 
-of methods; functions, constructors and behaviours. All methods are attached to 
-type definitions (e.g. classes), there are no global functions.
+All Pony code that actually does something, rather than defining types etc, appears in named blocks which are referred to as methods. There are three kinds of methods; functions, constructors and behaviours. All methods are attached to type definitions (e.g. classes), there are no global functions.
 
-Behaviours are used for handling asynchronous messages sent to actors. We'll 
-look at those later.
+Behaviours are used for handling asynchronous messages sent to actors. We'll look at those later.
 
-__Can I have some code outside of any methods, like I do in Python?__ No. All 
-Pony code must be within a method.
+__Can I have some code outside of any methods, like I do in Python?__ No. All Pony code must be within a method.
 
 ## Functions
 
-Pony functions are quite like functions (or methods) in other languages. They 
-can have 0 or more parameters and 0 or 1 return values.
+Pony functions are quite like functions (or methods) in other languages. They can have 0 or more parameters and 0 or 1 return values.
 
 ```pony
 class C
@@ -25,28 +19,15 @@ class C
     add(1, 2)  // Pointless, we ignore the result
 ```
 
-The function parameters (if any) are specified in parentheses after the 
-function name. Functions that don't take any parameters still need to have the 
-parentheses.
+The function parameters (if any) are specified in parentheses after the function name. Functions that don't take any parameters still need to have the parentheses.
 
-Each parameter is given a name and a type. In our example function `add` has 2 
-parameters, `x` and `y`, both of which are type `U32`. The values passed to a 
-function call (the `1` and `2` in our example) are called arguments and when 
-the call is made they are evaluated and assigned to the parameters. Parameters 
-may not be assigned to within the function, they are effectively declared `let`.
+Each parameter is given a name and a type. In our example function `add` has 2 parameters, `x` and `y`, both of which are type `U32`. The values passed to a function call (the `1` and `2` in our example) are called arguments and when the call is made they are evaluated and assigned to the parameters. Parameters may not be assigned to within the function, they are effectively declared `let`.
 
-After the parameters comes the return type. If nothing will be returned this is 
-simply omitted.
+After the parameters comes the return type. If nothing will be returned this is simply omitted.
 
-After the return value there's a `=>` and then finally the function body. The 
-value returned is simply the value of the function body (remember that 
-everything is an expression), which is simply the value of the last command in 
-the function.
+After the return value there's a `=>` and then finally the function body. The value returned is simply the value of the function body (remember that everything is an expression), which is simply the value of the last command in the function.
 
-If you want to exit a function early then use the `return` command. If the 
-function has a return type then you need to provide a value to return. If the 
-function does not have a return type then `return` should appear on its own, 
-without a value.
+If you want to exit a function early then use the `return` command. If the function has a return type then you need to provide a value to return. If the function does not have a return type then `return` should appear on its own, without a value.
 
 ```pony
 class C
@@ -58,16 +39,11 @@ class C
 	x * factorial(x - 1)
 ```
 
-__Can I overload functions by argument type?__ No. There is no overloading of 
-methods in Pony, each type may only have a single method of any given name.
+__Can I overload functions by argument type?__ No. There is no overloading of methods in Pony, each type may only have a single method of any given name.
 
 ## Constructors
 
-Pony constructors are used to initialise newly created objects, as in many 
-languages. However, unlike many languages, Pony constructors are named so you 
-can have as many as you like, taking whatever parameters you like. By 
-convention the main constructor of each type (if there is such a thing for any 
-given type) is called `create`.
+Pony constructors are used to initialise newly created objects, as in many languages. However, unlike many languages, Pony constructors are named so you can have as many as you like, taking whatever parameters you like. By convention the main constructor of each type (if there is such a thing for any given type) is called `create`.
 
 ```pony
 class Foo
@@ -80,18 +56,13 @@ class Foo
     _x = x
 ```
 
-The purpose of a constructor is to set up the internal state of the object 
-being created. To ensure this is done constructors must initialise all the 
-fields in the object being constructed.
+The purpose of a constructor is to set up the internal state of the object being created. To ensure this is done constructors must initialise all the fields in the object being constructed.
 
-__Can I exit a constructor early?__ Yes. Just then use the `return` command 
-without a value. The object must already be in a legal state to do this.
+__Can I exit a constructor early?__ Yes. Just then use the `return` command without a value. The object must already be in a legal state to do this.
 
 ## Calling
 
-As in many other languages, methods in Pony are called by providing the 
-arguments within parentheses after the method name. The parentheses are 
-required even if there are no arguments being passed to the method.
+As in many other languages, methods in Pony are called by providing the arguments within parentheses after the method name. The parentheses are required even if there are no arguments being passed to the method.
 
 ```pony
 class Foo
@@ -102,9 +73,7 @@ class Foo
     let a = hello("Fred")
 ```
 
-Constructors are usually called "on" a type, by specifying the type that is to 
-be created. To do this just specify the type, followed by a dot, followed by 
-the name of the constructor you want to call.
+Constructors are usually called "on" a type, by specifying the type that is to be created. To do this just specify the type, followed by a dot, followed by the name of the constructor you want to call.
 
 ```pony
 class Foo
@@ -122,9 +91,7 @@ class Bar
 	var b: Foo = Foo.from_int(3)
 ```
 
-Functions are always called on an object. Again just specify the object, 
-followed by a dot, followed by the name of the function to call. If the object 
-to call on is omitted then the current object is used (i.e. `this`).
+Functions are always called on an object. Again just specify the object, followed by a dot, followed by the name of the function to call. If the object to call on is omitted then the current object is used (i.e. `this`).
 
 ```pony
 class Foo
@@ -150,9 +117,7 @@ class Bar
 
 ```
 
-Constructors can also be called on an expression. Here an object is created of 
-the same type as the specified expression, this is equivalent to directly 
-specifying the type.
+Constructors can also be called on an expression. Here an object is created of the same type as the specified expression, this is equivalent to directly specifying the type.
 
 ```pony
 class Foo
@@ -172,10 +137,7 @@ class Bar
 
 ## Default arguments
 
-When defining a method you can provide default values for any of the arguments. 
-The caller then has the choice to use the values you have provided or to 
-provide their own. Default argument values are specified with a `=` after the 
-parameter name.
+When defining a method you can provide default values for any of the arguments. The caller then has the choice to use the values you have provided or to provide their own. Default argument values are specified with a `=` after the parameter name.
 
 ```pony
 class Coord
@@ -193,18 +155,13 @@ class Bar
 	var b: Coord = Coord.create(3, 4) // Contains (3, 4)
 ```
 
-__Do I have to provide default values for all of my arguments?__ No, you can 
-provide defaults for as many, or as few, as you like.
+__Do I have to provide default values for all of my arguments?__ No, you can provide defaults for as many, or as few, as you like.
 
 ## Named arguments
 
-So far, when calling methods we have always given all the arguments in order. 
-This is known as using __positional__ arguments. However, you can also specify 
-the arguments in any order you like by specifying their names. This is known as 
-using __named__ arguments.
+So far, when calling methods we have always given all the arguments in order. This is known as using __positional__ arguments. However, you can also specify the arguments in any order you like by specifying their names. This is known as using __named__ arguments.
 
-To call a method using named arguments use the `where` keyword, followed by the 
-named arguments and their values.
+To call a method using named arguments use the `where` keyword, followed by the named arguments and their values.
 
 ```pony
 class Coord
@@ -220,16 +177,11 @@ class Bar
     var a: Coord = Coord.create(where y = 4, x = 3)
 ```
 
-__Should I specify `where` for each named argument?__ No. There must only be 
-one `where` in each method call.
+__Should I specify `where` for each named argument?__ No. There must only be one `where` in each method call.
 
-Named and positional arguments can be used together in a single call. Just 
-start with the positional arguments you want to specify, then a `where` and 
-finally the named arguments. But be careful, each argument must be specified 
-only once.
+Named and positional arguments can be used together in a single call. Just start with the positional arguments you want to specify, then a `where` and finally the named arguments. But be careful, each argument must be specified only once.
 
-Default arguments can also be used in combination with positional and named 
-arguments, just miss out any for which you want to use the default.
+Default arguments can also be used in combination with positional and named arguments, just miss out any for which you want to use the default.
 
 ```pony
 class Foo
@@ -242,16 +194,10 @@ class Foo
 	f(6, 7, 3, 8, 5)
 ```
 
-__Can I call using positional arguments but miss out the first one?__ No. If 
-you use positional arguments they must be the first ones in the call.
+__Can I call using positional arguments but miss out the first one?__ No. If you use positional arguments they must be the first ones in the call.
 
 ## Privacy
 
-In Pony method names start either with a lower case letter or with an 
-underscore followed by a lower case letter. Methods with a leading underscore 
-are private. This means they can only be called by code within the same 
-package. Methods without a leading underscore are public and can be called by 
-anyone.
+In Pony method names start either with a lower case letter or with an underscore followed by a lower case letter. Methods with a leading underscore are private. This means they can only be called by code within the same package. Methods without a leading underscore are public and can be called by anyone.
 
-__Can I start my method name with 2 (or more) underscores?__ No. If the first 
-character is an underscore then the second one MUST be a lower case letter.
+__Can I start my method name with 2 (or more) underscores?__ No. If the first character is an underscore then the second one MUST be a lower case letter.

--- a/expressions/object-literals.md
+++ b/expressions/object-literals.md
@@ -1,19 +1,12 @@
 # Object Literals
 
-Sometimes it's really convenient to be able to write a whole object inline. In 
-Pony, this is called an object literal, and it does pretty much exactly what an 
-object literal in JavaScript does: it creates an object that you can use 
-immediately.
+Sometimes it's really convenient to be able to write a whole object inline. In Pony, this is called an object literal, and it does pretty much exactly what an object literal in JavaScript does: it creates an object that you can use immediately.
 
-But Pony is statically typed, so an object literal also creates an anonymous 
-type that the object literal fulfills. This is similar to anonymous classes in 
-Java and C#. In Pony, an anonymous type can provide any number of traits and 
-interfaces.
+But Pony is statically typed, so an object literal also creates an anonymous type that the object literal fulfills. This is similar to anonymous classes in Java and C#. In Pony, an anonymous type can provide any number of traits and interfaces.
 
 ## What's this look like, then?
 
-It basically looks like any other type definition, but with some small 
-differences. Here's a simple one:
+It basically looks like any other type definition, but with some small differences. Here's a simple one:
 
 ```pony
 object
@@ -21,9 +14,7 @@ object
 end
 ```
 
-Ok, that's pretty trivial. Let's extend it so that it explicitly provides an 
-interface, so that the compiler will make sure the anonymous type fulfills that 
-interface. You can use the same notation to provide traits as well.
+Ok, that's pretty trivial. Let's extend it so that it explicitly provides an interface, so that the compiler will make sure the anonymous type fulfills that interface. You can use the same notation to provide traits as well.
 
 ```pony
 object is Hashable
@@ -32,9 +23,7 @@ object is Hashable
 end
 ```
 
-What we can't do is specify constructors in an object literal, because literal 
-_is_ the constructor. So how do we assign to fields? Well, we just assign to 
-them. For example:
+What we can't do is specify constructors in an object literal, because literal _is_ the constructor. So how do we assign to fields? Well, we just assign to them. For example:
 
 ```pony
 class Foo
@@ -46,19 +35,13 @@ class Foo
     end
 ```
 
-When we assign to a field in the constructor, we are _capturing_ from the 
-lexical scope the object literal is in. Pretty fun stuff! It lets us have 
-arbitrarily complex __closures__ that can even have multiple entry points 
-(i.e. functions you can call on a closure).
+When we assign to a field in the constructor, we are _capturing_ from the lexical scope the object literal is in. Pretty fun stuff! It lets us have arbitrarily complex __closures__ that can even have multiple entry points (i.e. functions you can call on a closure).
 
-An object literal is always returned as a `ref`, like a default constructor on 
-a class. To get another reference capability (`iso`, `val`, etc.), you can wrap 
-the object literal in a `recover` expression.
+An object literal is always returned as a `ref`, like a default constructor on a class. To get another reference capability (`iso`, `val`, etc.), you can wrap the object literal in a `recover` expression.
 
 ## Lambdas
 
-Arbitrarily complex closures are nice, but sometimes we just want a simple 
-closure. In Pony, you can use the `lambda` keyword for that.
+Arbitrarily complex closures are nice, but sometimes we just want a simple closure. In Pony, you can use the `lambda` keyword for that.
 
 ```pony
 lambda(s: String): String => "lambda: " + s end
@@ -72,9 +55,7 @@ object
 end
 ```
 
-The `lambda` keyword can be used to capture from lexical scope in the same way 
-as object literals can assign from the lexical scope to a field. This is done 
-by adding a second parameter list after the arguments:
+The `lambda` keyword can be used to capture from lexical scope in the same way as object literals can assign from the lexical scope to a field. This is done by adding a second parameter list after the arguments:
 
 ```pony
 class Foo
@@ -85,25 +66,16 @@ class Foo
     f("Hello World")
 ```
 
-The captured variables can be renamed if desired by assigning a new name in 
-the capture parameter list:
+The captured variables can be renamed if desired by assigning a new name in the capture parameter list:
 
 ```pony
   new create(env:Env) =>
     foo(lambda(s: String)(myenv=env) => myenv.out.print(s) end)
 ```
 
-The type of a lambda is declared using curly brackets. Within the brackets the 
-function parameter types are specified within parentheses followed by an 
-optional colon and return type. The example above uses `{(String)}` to be the 
-type of a lambda function that takes a `String` as an argument and returns 
-nothing.
+The type of a lambda is declared using curly brackets. Within the brackets the function parameter types are specified within parentheses followed by an optional colon and return type. The example above uses `{(String)}` to be the type of a lambda function that takes a `String` as an argument and returns nothing.
 
-A lambda object is always returned as `val` if it does not close over any other 
-variables. If it does capture values from the lexical scope then it is returned 
-as a `ref`. The reference capability in the type declaration can be supplied by 
-adding it before the closing curly bracket. If it is not provided it defaults 
-to `ref`. The following is an example of a `val` lambda object:
+A lambda object is always returned as `val` if it does not close over any other variables. If it does capture values from the lexical scope then it is returned as a `ref`. The reference capability in the type declaration can be supplied by adding it before the closing curly bracket. If it is not provided it defaults to `ref`. The following is an example of a `val` lambda object:
 
 ```pony
 actor Main
@@ -122,18 +94,9 @@ actor Main
     end
 ```
 
-`reduce` in this example declares the lambda type to have reference capability 
-`val`. It is required here as the default for the type declaration is `ref` and 
-that would not match with the lambda object being used in the `reduce` call - 
-that defaults to `val` as it isn't capturing anything from the lexical scope.
+`reduce` in this example declares the lambda type to have reference capability `val`. It is required here as the default for the type declaration is `ref` and that would not match with the lambda object being used in the `reduce` call - that defaults to `val` as it isn't capturing anything from the lexical scope.
 
-As mentioned previously the lambda desugars to an object literal with an 
-`apply` method. The reference capability for the `apply` method defaults to 
-`box` like any other method. In a lambda that captures this needs to be `ref` 
-if the function needs to modify any of the captured variables or call `ref` 
-methods on them. The reference capabiltity for the method (versus the reference 
-capability for the object which was described above) is defined by putting the 
-capability before the parenthesized argument list.
+As mentioned previously the lambda desugars to an object literal with an `apply` method. The reference capability for the `apply` method defaults to `box` like any other method. In a lambda that captures this needs to be `ref` if the function needs to modify any of the captured variables or call `ref` methods on them. The reference capabiltity for the method (versus the reference capability for the object which was described above) is defined by putting the capability before the parenthesized argument list.
 
 ```pony
 actor Main
@@ -155,17 +118,11 @@ actor Main
     end
 ```
 
-This example declares the type of the apply function that is generated by the 
-lambda expression as being `ref`. The type declaration for it in the `for_each` 
-method also declares it as `ref`. The lambda function captures some variables 
-so the object that is generated is `ref` and the default for the type 
-declaration is `ref` so everything type checks.
+This example declares the type of the apply function that is generated by the lambda expression as being `ref`. The type declaration for it in the `for_each` method also declares it as `ref`. The lambda function captures some variables so the object that is generated is `ref` and the default for the type declaration is `ref` so everything type checks.
 
 ## Actor literals
 
-Normally, an object literal is an instance of an anonymous class. To make it an 
-instance of an anonymous actor, just include one or more behaviours in the 
-object literal definition.
+Normally, an object literal is an instance of an anonymous class. To make it an instance of an anonymous actor, just include one or more behaviours in the object literal definition.
 
 ```pony
 object
@@ -178,10 +135,7 @@ An actor literal is always returned as a `tag`.
 
 ## Primitive literals
 
-When an anonymous type has no fields and no behaviours (like, for example, an 
-object literal declared with the `lambda` keyword), the compiler generates it 
-as an anonymous primitive. This means no memory allocation is needed to 
-generate an instance of that type.
+When an anonymous type has no fields and no behaviours (like, for example, an object literal declared with the `lambda` keyword), the compiler generates it as an anonymous primitive. This means no memory allocation is needed to generate an instance of that type.
 
 In other words, a lambda in Pony has no memory allocation overhead. Nice.
 

--- a/expressions/partial-application.md
+++ b/expressions/partial-application.md
@@ -1,8 +1,6 @@
 # Partial Application
 
-Partial application lets us supply _some_ of the arguments to a constructor, 
-function, or behaviour, and get back something that lets us supply the rest of 
-the arguments later.
+Partial application lets us supply _some_ of the arguments to a constructor, function, or behaviour, and get back something that lets us supply the rest of the arguments later.
 
 ## A simple case
 
@@ -22,11 +20,7 @@ class Bar
     f(4)
 ```
 
-This is a bit of a silly example, but hopefully the idea is clear. We partially 
-apply the `addmul` function on `foo`, binding the receiver to `foo` and the 
-`add` argument to `3`. We get back an object, `f`, that has an `apply` method 
-that takes a `mul` argument. When it's called, it in turn calls 
-`foo.addmul(3, mul)`.
+This is a bit of a silly example, but hopefully the idea is clear. We partially apply the `addmul` function on `foo`, binding the receiver to `foo` and the `add` argument to `3`. We get back an object, `f`, that has an `apply` method that takes a `mul` argument. When it's called, it in turn calls `foo.addmul(3, mul)`.
 
 We can also bind all the arguments:
 
@@ -44,8 +38,7 @@ f(3, 4)
 
 ## Out of order arguments
 
-Partial application with named arguments allows binding arguments in any order, 
-not just left to right. For example:
+Partial application with named arguments allows binding arguments in any order, not just left to right. For example:
 
 ```pony
 let f = foo~addmul(where mul = 4)
@@ -56,8 +49,7 @@ Here, we bound the `mul` argument, but left `add` unbound.
 
 ## Partially applying a partial application
 
-Since partial application results in an object with an apply method, we can 
-partially apply the result!
+Since partial application results in an object with an apply method, we can partially apply the result!
 
 ```pony
 let f = foo~addmul()
@@ -67,12 +59,6 @@ f2(3)
 
 ## Partial application is an object literal
 
-Under the hood, we're assembling an object literal for partial application. It 
-captures some of the lexical scope as fields, and has an `apply` method that 
-takes some, possibly reduced, number of arguments. This is actually done as 
-sugar, by rewriting the abstract syntax tree for partial application to be an 
-object literal, before code generation.
+Under the hood, we're assembling an object literal for partial application. It captures some of the lexical scope as fields, and has an `apply` method that takes some, possibly reduced, number of arguments. This is actually done as sugar, by rewriting the abstract syntax tree for partial application to be an object literal, before code generation.
 
-That means partial application results in an anonymous class, and returns a 
-`ref`. If you need another reference capability, you can wrap partial 
-application in a `recover` expression.
+That means partial application results in an anonymous class, and returns a `ref`. If you need another reference capability, you can wrap partial application in a `recover` expression.

--- a/expressions/sugar.md
+++ b/expressions/sugar.md
@@ -1,15 +1,10 @@
 # Sugar
 
-Pony allows you to omit certain small details from your code and will put them 
-back in for you. This is done to help make your code less cluttered and more 
-readable. Using sugar is entirely optional, you can always write out the full 
-version if you prefer.
+Pony allows you to omit certain small details from your code and will put them back in for you. This is done to help make your code less cluttered and more readable. Using sugar is entirely optional, you can always write out the full version if you prefer.
 
 ## Apply
 
-Many Pony classes have a function called `apply` which performs whatever action 
-is most common for that type. Pony allows you to omit the word `apply` and just 
-attempt to do a call directly on the object. So:
+Many Pony classes have a function called `apply` which performs whatever action is most common for that type. Pony allows you to omit the word `apply` and just attempt to do a call directly on the object. So:
 
 ```pony
 var foo = Foo.create()
@@ -37,19 +32,13 @@ var foo = Foo.create()
 foo.apply(x, 37 where crash = false)
 ```
 
-__Do I still need to provide the arguments to apply?__ Yes, only the `apply` 
-will be added for you, the correct number and type of arguments must be 
-supplied. Default and named arguments can be used as normal.
+__Do I still need to provide the arguments to apply?__ Yes, only the `apply` will be added for you, the correct number and type of arguments must be supplied. Default and named arguments can be used as normal.
 
-__How do I call a function foo if apply is added?__ The `apply` sugar is only 
-added when calling an object, not when calling a method. The compiler can tell 
-the difference and only adds the `apply` when appropriate.
+__How do I call a function foo if apply is added?__ The `apply` sugar is only added when calling an object, not when calling a method. The compiler can tell the difference and only adds the `apply` when appropriate.
 
 ## Create
 
-To create an object you need to specify the type and call a constructor. Pony 
-allows you to miss out the constructor and will insert a call to `create()` for 
-you. So:
+To create an object you need to specify the type and call a constructor. Pony allows you to miss out the constructor and will insert a call to `create()` for you. So:
 
 ```pony
 var foo = Foo
@@ -61,12 +50,9 @@ becomes:
 var foo = Foo.create()
 ```
 
-Normally types are not valid things to appear in expressions, so omitting the 
-constructor call is not ambiguous. Remember that you can easily spot that a 
-name is a type because it will start with a capital letter.
+Normally types are not valid things to appear in expressions, so omitting the constructor call is not ambiguous. Remember that you can easily spot that a name is a type because it will start with a capital letter.
 
-If arguments are needed for create these can be provided as if calling the 
-type. Default and named arguments can be used as normal.
+If arguments are needed for create these can be provided as if calling the type. Default and named arguments can be used as normal.
 
 ```pony
 var foo = Foo(x, 37 where crash = false)
@@ -78,19 +64,13 @@ becomes:
 var foo = Foo.create(x, 37 where crash = false)
 ```
 
-__What if I want to use a constructor that isn't named create?__ Then the sugar 
-can't help you and you have to write it out yourself.
+__What if I want to use a constructor that isn't named create?__ Then the sugar can't help you and you have to write it out yourself.
 
-__If the create I want to call takes no arguments can I still put in the 
-parentheses?__ No. Calls of the form `Type()` use the combined create-apply 
-sugar (see below). To get `Type.create()` just use `Type`.
+__If the create I want to call takes no arguments can I still put in the parentheses?__ No. Calls of the form `Type()` use the combined create-apply sugar (see below). To get `Type.create()` just use `Type`.
 
 ## Combined create-apply
 
-If a type has a create constructor that takes no arguments then the create and 
-apply sugar can be used together. Just call on the type and calls to create and 
-apply will be added. The call to create will take no arguments and the call to 
-apply will take whatever arguments are supplied.
+If a type has a create constructor that takes no arguments then the create and apply sugar can be used together. Just call on the type and calls to create and apply will be added. The call to create will take no arguments and the call to apply will take whatever arguments are supplied.
 
 ```pony
 var foo = Foo()
@@ -104,20 +84,13 @@ var foo = Foo.create().apply()
 var bar = Bar.create().apply(x, 37 where crash = false)
 ```
 
-__What if the create has default arguments? Do I get the combined create-apply 
-sugar if I want to use the defaults?__ The combined create-apply sugar can only 
-be used when the create constructor has no arguments. If there are default 
-arguments then this sugar cannot be used.
+__What if the create has default arguments? Do I get the combined create-apply sugar if I want to use the defaults?__ The combined create-apply sugar can only be used when the create constructor has no arguments. If there are default arguments then this sugar cannot be used.
 
 ## Update
 
-The `update` sugar allows any class to use an assignment to accept data. Many 
-languages allow this for assigning into collections, for example a simple C 
-array, `a[3] = x;`.
+The `update` sugar allows any class to use an assignment to accept data. Many languages allow this for assigning into collections, for example a simple C array, `a[3] = x;`.
 
-In any assignment where the left hand side is a function call, Pony will 
-translate this to a call to update, with the value from the right hand side as 
-an extra argument. So:
+In any assignment where the left hand side is a function call, Pony will translate this to a call to update, with the value from the right hand side as an extra argument. So:
 
 ```pony
 foo(37) = x
@@ -129,13 +102,9 @@ becomes:
 foo.update(37 where value = x)
 ```
 
-The value from the right hand side of the assignment is always passed to a 
-parameter named `value`. Any object can allow this syntax simply by providing 
-an appropriate function `update` with an argument `value`.
+The value from the right hand side of the assignment is always passed to a parameter named `value`. Any object can allow this syntax simply by providing an appropriate function `update` with an argument `value`.
 
-__Does my update function have to have a single parameter that takes an 
-integer?__ No, you can define update to take whatever parameters you like, as 
-long as there is one called `value`. The following are all fine:
+__Does my update function have to have a single parameter that takes an integer?__ No, you can define update to take whatever parameters you like, as long as there is one called `value`. The following are all fine:
 
 ```pony
 foo1(2, 3) = x
@@ -143,6 +112,4 @@ foo2() = x
 foo3(37, "Hello", 3.5 where a = 2, b = 3) = x
 ```
 
-__Does it matter where `value` appears in my parameter list?__ Whilst it 
-doesn't strictly matter it is good practice to put `value` as the last 
-parameter. That way all of the others can be specified by position.
+__Does it matter where `value` appears in my parameter list?__ Whilst it doesn't strictly matter it is good practice to put `value` as the last parameter. That way all of the others can be specified by position.

--- a/expressions/variables.md
+++ b/expressions/variables.md
@@ -1,20 +1,12 @@
 # Variables
 
-Like most other programming languages Pony allows you to store data in 
-variables. There are a few different kinds of variables which have different 
-lifetimes and are used for slightly different purposes.
+Like most other programming languages Pony allows you to store data in variables. There are a few different kinds of variables which have different lifetimes and are used for slightly different purposes.
 
 ## Local variables
 
-Local variables in Pony work very much as they do in other languages, allowing 
-you to store temporary values while you perform calculations. Local variables 
-live within a chunk of code (they are _local_ to that chunk) and are created 
-every time that code chunk executes and disposed of when it completes.
+Local variables in Pony work very much as they do in other languages, allowing you to store temporary values while you perform calculations. Local variables live within a chunk of code (they are _local_ to that chunk) and are created every time that code chunk executes and disposed of when it completes.
 
-To define a local variable the `var` keyword is used (`let` can also be used, 
-but we'll get to that later). Right after the `var` comes the variable's name, 
-and then you can (optionally) put a `:` followed by the variable's type. For 
-example:
+To define a local variable the `var` keyword is used (`let` can also be used, but we'll get to that later). Right after the `var` comes the variable's name, and then you can (optionally) put a `:` followed by the variable's type. For example:
 
 ```pony
 var x: String = "Hello"
@@ -22,14 +14,9 @@ var x: String = "Hello"
 
 Here, we're assigning the __string literal__ `"Hello"` to `x`.
 
-You don't have to give a value to the variable when you define it: you can 
-assign one later if you prefer. If you try to read the value from a variable 
-before you've assigned one, the compiler will complain instead of allowing the 
-dreaded _uninitialised variable_ bug.
+You don't have to give a value to the variable when you define it: you can assign one later if you prefer. If you try to read the value from a variable before you've assigned one, the compiler will complain instead of allowing the dreaded _uninitialised variable_ bug.
 
-Every variable has a type, but you don't have to specify it in the declaration 
-if you provide an initial value. The compiler will automatically use the type 
-of the initial value for the variable.
+Every variable has a type, but you don't have to specify it in the declaration if you provide an initial value. The compiler will automatically use the type of the initial value for the variable.
 
 The following definitions of `x`, `y` and `z` are all effectively identical.
 
@@ -42,19 +29,11 @@ var z: String
 z = "Hello"
 ```
 
-__Can I miss out both the type and initial value for a variable?__ No. The 
-compiler will complain that it can't figure out a type for that variable.
+__Can I miss out both the type and initial value for a variable?__ No. The compiler will complain that it can't figure out a type for that variable.
 
-All local variable names start with a lower case letter. If you want to you can 
-end them with a _prime_ `'` (or more than one) which is useful when you need a 
-second variable with almost the same meaning as the first. For example you 
-might have one variable called `time` and another called `time'`.
+All local variable names start with a lower case letter. If you want to you can end them with a _prime_ `'` (or more than one) which is useful when you need a second variable with almost the same meaning as the first. For example you might have one variable called `time` and another called `time'`.
 
-The chunk of code that a variable lives in is known as its __scope__. Exactly 
-what its scope is depends on where it is defined. For example, the scope of a 
-variable defined within the `then` expression of an `if` statement is that 
-`then` expression. We haven't looked at `if` statements yet, but they're very 
-similar to every other language.
+The chunk of code that a variable lives in is known as its __scope__. Exactly what its scope is depends on where it is defined. For example, the scope of a variable defined within the `then` expression of an `if` statement is that `then` expression. We haven't looked at `if` statements yet, but they're very similar to every other language.
 
 ```pony
 if a > b then
@@ -65,15 +44,11 @@ end
 env.out.print(x)  // Illegal
 ```
 
-Variables only exists from when they are defined until the end of the current 
-scope. For our variable `x` this is the `end` at the end of the then 
-expression: after that it cannot be used.
+Variables only exists from when they are defined until the end of the current scope. For our variable `x` this is the `end` at the end of the then expression: after that it cannot be used.
 
 ## Var vs. let
 
-Local variables are declared with either a `var` or a `let`. Using `var` means 
-the variable can be assigned and reassigned as many times as you like. Using 
-`let` means the variable can only be assigned once.
+Local variables are declared with either a `var` or a `let`. Using `var` means the variable can be assigned and reassigned as many times as you like. Using `let` means the variable can only be assigned once.
 
 ```pony
 var x: U32 = 3
@@ -82,39 +57,24 @@ x = 5  // OK
 y = 6  // Error, y is let
 ```
 
-You never have to declare variables as `let`, but if you know you're never 
-going to change a variable then using `let` is a good way to catch errors. It 
-can also serve as a useful comment, indicating the value is not meant to be 
-changed.
+You never have to declare variables as `let`, but if you know you're never going to change a variable then using `let` is a good way to catch errors. It can also serve as a useful comment, indicating the value is not meant to be changed.
 
 ## Fields
 
-In Pony, fields are variables that live within objects. They work like fields 
-in other object-oriented languages.
+In Pony, fields are variables that live within objects. They work like fields in other object-oriented languages.
 
-Fields have the same lifetime as the object they're in, rather than being 
-scoped. They are set up by the object constructor and disposed of along with 
-the object.
+Fields have the same lifetime as the object they're in, rather than being scoped. They are set up by the object constructor and disposed of along with the object.
 
-If the name of a field starts with `_`, it's __private__. That means only the 
-type the field is in can have code that reads or writes that field. Otherwise, 
-the field is __public__, and can be read or written anywhere.
+If the name of a field starts with `_`, it's __private__. That means only the type the field is in can have code that reads or writes that field. Otherwise, the field is __public__, and can be read or written anywhere.
 
-Just like local variables, fields can be `var` or `let`. They can also have 
-initial value assigned in their definition, just like local variables, or they 
-can be given their initial value in a constructor.
+Just like local variables, fields can be `var` or `let`. They can also have initial value assigned in their definition, just like local variables, or they can be given their initial value in a constructor.
 
 ## Globals
 
-Some programming languages have __global variables__ that can be accessed from 
-anywhere in the code. What a bad idea! Pony doesn't have global variables at 
-all.
+Some programming languages have __global variables__ that can be accessed from anywhere in the code. What a bad idea! Pony doesn't have global variables at all.
 
 ## Shadowing
 
-Some programming languages let you declare a variable with the same name as an 
-existing variable, and then there are rules about which one you get. This is 
-called _shadowing_, and it's a source of bugs. If you accidentally shadow a 
-variable in Pony, the compiler will complain.
+Some programming languages let you declare a variable with the same name as an existing variable, and then there are rules about which one you get. This is called _shadowing_, and it's a source of bugs. If you accidentally shadow a variable in Pony, the compiler will complain.
 
 If you need a variable with _nearly_ the same name, you can use a prime `'`.

--- a/getting-started/hello-world.md
+++ b/getting-started/hello-world.md
@@ -1,26 +1,19 @@
 # Hello World: Your First Pony Program
 
-Now that you've successfully installed the Pony compiler, let's start
-programming! Our first program will be a very traditional one. We're going to
-print "Hello, world!". First, create a directory called `helloworld`:
+Now that you've successfully installed the Pony compiler, let's start programming! Our first program will be a very traditional one. We're going to print "Hello, world!". First, create a directory called `helloworld`:
 
 ```bash
 $ mkdir helloworld
 $ cd helloworld
 ```
 
-__Does the name of the directory matter?__ Yes, it does. It's the name of your 
-program! When your program is compiled, the resulting executable binary will 
-have the same name as the directory your program lives in.
+__Does the name of the directory matter?__ Yes, it does. It's the name of your program! When your program is compiled, the resulting executable binary will have the same name as the directory your program lives in.
 
 ## The code
 
-Then, create a file in that directory called `main.pony`. 
+Then, create a file in that directory called `main.pony`.
 
-__Does the name of the file matter?__ Not to the compiler, no. Pony doesn't 
-care about filenames other than that they end in `.pony`. But it might matter 
-to you! By giving files good names, it can be easier to find the code you're 
-looking for later.
+__Does the name of the file matter?__ Not to the compiler, no. Pony doesn't care about filenames other than that they end in `.pony`. But it might matter to you! By giving files good names, it can be easier to find the code you're looking for later.
 
 In your file, put the following code:
 
@@ -44,16 +37,9 @@ Writing ./helloworld.o
 Linking ./helloworld
 ```
 
-Look at that! It built the current directory, `.`, plus the stuff that is built 
-in to Pony, `builtin`, it generated some code, optimised it, created an object 
-file (don't worry if you don't know what that is), and linked it into an 
-executable with whatever libraries were needed. If you're a C/C++ programmer, 
-that will all make sense to you, otherwise it probably won't, but that's ok, 
-you can ignore it.
+Look at that! It built the current directory, `.`, plus the stuff that is built in to Pony, `builtin`, it generated some code, optimised it, created an object file (don't worry if you don't know what that is), and linked it into an executable with whatever libraries were needed. If you're a C/C++ programmer, that will all make sense to you, otherwise it probably won't, but that's ok, you can ignore it.
 
-__Wait, it linked too?__ Yes. You won't need a build system (like `make`) for 
-Pony. It handles that for you (including handling the order of dependencies 
-when you link to C libraries, but we'll get to that later).
+__Wait, it linked too?__ Yes. You won't need a build system (like `make`) for Pony. It handles that for you (including handling the order of dependencies when you link to C libraries, but we'll get to that later).
 
 ## Running the program
 
@@ -64,5 +50,4 @@ $ ./helloworld
 Hello, world!
 ```
 
-Congratulations, you've written your first Pony program! Next, we'll explain 
-what some of that code does.
+Congratulations, you've written your first Pony program! Next, we'll explain what some of that code does.

--- a/getting-started/how-it-works.md
+++ b/getting-started/how-it-works.md
@@ -16,17 +16,11 @@ Let's go through that line by line.
 actor Main
 ```
 
-This is a __type declaration__. The keyword `actor` means we are going to 
-define an actor, which is a bit like a class in Python, Java, C#, C++, etc. 
-Pony has classes too, which we'll see later.
+This is a __type declaration__. The keyword `actor` means we are going to define an actor, which is a bit like a class in Python, Java, C#, C++, etc. Pony has classes too, which we'll see later.
 
-The difference between an actor and a class is that an actor can have 
-__asynchronous__ methods, called __behaviours__. We'll talk more about that 
-later.
+The difference between an actor and a class is that an actor can have __asynchronous__ methods, called __behaviours__. We'll talk more about that later.
 
-A Pony program has to have a `Main` actor. It's kind of like the `main` 
-function in C or C++, or the `main` method in Java, or the `Main` method in C#. 
-It's where the action starts.
+A Pony program has to have a `Main` actor. It's kind of like the `main` function in C or C++, or the `main` method in Java, or the `Main` method in C#. It's where the action starts.
 
 ## Line 2
 
@@ -34,23 +28,15 @@ It's where the action starts.
   new create(env: Env) =>
 ```
 
-This is a __constructor__. The keyword `new` means it's a function that creates 
-a new instance of the type. In this case, it creates a new __Main__.
+This is a __constructor__. The keyword `new` means it's a function that creates a new instance of the type. In this case, it creates a new __Main__.
 
-Unlike other languages, constructors in Pony have names. That means there can 
-be more than one way to construct an instance of a type. In this case, the name 
-of the constructor is `create`.
+Unlike other languages, constructors in Pony have names. That means there can be more than one way to construct an instance of a type. In this case, the name of the constructor is `create`.
 
-The parameters of a function come next. In this case, our constructor has a 
-single parameter called `env` that is of the type `Env`.
+The parameters of a function come next. In this case, our constructor has a single parameter called `env` that is of the type `Env`.
 
-In Pony, the type of something always comes after its name, and is separated by 
-a colon. In C, C++, Java or C#, you might say `Env env`, but we do it the other 
-way around (like Go, Pascal, and a bunch of other languages).
+In Pony, the type of something always comes after its name, and is separated by a colon. In C, C++, Java or C#, you might say `Env env`, but we do it the other way around (like Go, Pascal, and a bunch of other languages).
 
-It turns out, our `Main` actor __has__ to have a constructor called `create` 
-that takes a single parameter of type `Env`. That's how all programs start! So 
-the beginning of your program is essentially the body of that constructor.
+It turns out, our `Main` actor __has__ to have a constructor called `create` that takes a single parameter of type `Env`. That's how all programs start! So the beginning of your program is essentially the body of that constructor.
 
 __Wait, what's the body?__ It's the code that comes after the `=>`.
 
@@ -62,29 +48,14 @@ __Wait, what's the body?__ It's the code that comes after the `=>`.
 
 This is your program! What the heck is it doing?
 
-In Pony a dot is a either a field access or a method call, much like other 
-languages. If the name after the dot has parentheses after it, it's a method 
-call. Otherwise, it's a field access.
+In Pony a dot is a either a field access or a method call, much like other languages. If the name after the dot has parentheses after it, it's a method call. Otherwise, it's a field access.
 
-So here, we start with a reference to `env`. We then lookup the field `out` on 
-our object `env`. As it happens, that field represents __stdout__, i.e. usually 
-it means printing to your console. Then, we call the `print` method on 
-`env.out`. The stuff inside the parentheses are the arguments to the function. 
-In this case, we are passing a __string literal__, i.e. the stuff in double 
-quotes.
+So here, we start with a reference to `env`. We then lookup the field `out` on our object `env`. As it happens, that field represents __stdout__, i.e. usually it means printing to your console. Then, we call the `print` method on `env.out`. The stuff inside the parentheses are the arguments to the function. In this case, we are passing a __string literal__, i.e. the stuff in double quotes.
 
-In Pony, string literals can be in double quotes, in which case they follow 
-C/C++ style escaping (using stuff like \n), or they can be in "triple double" 
-quotes, like a Python triple quoted string, in which case they are considered 
-raw data.
+In Pony, string literals can be in double quotes, in which case they follow C/C++ style escaping (using stuff like \n), or they can be in "triple double" quotes, like a Python triple quoted string, in which case they are considered raw data.
 
-__What's an Env, anyway?__ It's the "environment" your program was invoked 
-with. That means it has command line arguments, environment variables, 
-__stdin__, __stdout__, and __stderr__. Pony has no global variables, so these 
-things are explicitly passed to your program.
+__What's an Env, anyway?__ It's the "environment" your program was invoked with. That means it has command line arguments, environment variables, __stdin__, __stdout__, and __stderr__. Pony has no global variables, so these things are explicitly passed to your program.
 
 ## That's it!
 
-Really, that's it. The program begins by creating a `Main` actor, and in the 
-constructor, we print "Hello, world!" to __stdout__. Next, we'll start diving
-into the Pony type system. 
+Really, that's it. The program begins by creating a `Main` actor, and in the constructor, we print "Hello, world!" to __stdout__. Next, we'll start diving into the Pony type system.

--- a/getting-started/index.md
+++ b/getting-started/index.md
@@ -1,4 +1,3 @@
 # Chapter 1: Getting Started with Pony
 
-This chapter will get you up and running with Pony from installing the compiler
-to running your first program.
+This chapter will get you up and running with Pony from installing the compiler to running your first program.

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -1,45 +1,40 @@
 # Installing the Pony compiler
 
-While there are versions of the Pony compiler already packaged up for use, they
-are currently out of date. Therefore we recommend installing the compiler from
-source. You can get the Pony source from 
-[GitHub](https://github.com/ponylang/ponyc). 
+While there are versions of the Pony compiler already packaged up for use, they are currently out of date. Therefore we recommend installing the compiler from source. You can get the Pony source from [GitHub](https://github.com/ponylang/ponyc).
 
-`git clone git@github.com:ponylang/ponyc.git`
+```bash
+git clone git@github.com:ponylang/ponyc.git
+```
 
-All the directions below, only build Pony in the directory you have cloned. If
-you want to install it, you should replace
+All the directions below, only build Pony in the directory you have cloned. If you want to install it, you should replace
 
-`make config=release` with `make config=release install`
+```bash
+make config=release` with `make config=release install
+```
 
 and to build the debug version of the compiler
 
-`make config=debug` instead of `make config=release`
+```bash
+make config=debug` instead of `make config=release
+```
 
 ## Using Docker
 
-Want to use the latest revision of Pony source, but don't want to build from 
-source yourself? You can run the `ponylang/ponyc` Docker container, which is 
-created from an automated build at each commit to master.
+Want to use the latest revision of Pony source, but don't want to build from source yourself? You can run the `ponylang/ponyc` Docker container, which is created from an automated build at each commit to master.
 
-You'll need to install Docker using 
-[the instructions here](https://docs.docker.com/engine/installation/). Then you 
-can pull the latest `ponylang/ponyc` image using this command:
+You'll need to install Docker using [the instructions here](https://docs.docker.com/engine/installation/). Then you can pull the latest `ponylang/ponyc` image using this command:
 
 ```bash
 docker pull ponylang/ponyc:latest
 ```
 
-Then you'll be able to run `ponyc` to compile a Pony program in a given 
-directory, running a command like this:
+Then you'll be able to run `ponyc` to compile a Pony program in a given directory, running a command like this:
 
 ```bash
 docker run -v /path/to/my-code:/src/main ponylang/ponyc
 ```
 
-Note that if your host doesn't match the docker container, you'll probably have 
-to run the resulting program inside the docker container as well, using a 
-command like this:
+Note that if your host doesn't match the docker container, you'll probably have to run the resulting program inside the docker container as well, using a command like this:
 
 ```bash
 docker run -v /path/to/my-code:/src/main ponylang/ponyc ./main
@@ -47,9 +42,7 @@ docker run -v /path/to/my-code:/src/main ponylang/ponyc ./main
 
 ## Mac OS X using [Homebrew](http://brew.sh)
 
-The homebrew version is currently woefully out of date. We are transitioning to
-a new release system that will keep homebrew up to date. For now, please build
-from source.
+The homebrew version is currently woefully out of date. We are transitioning to a new release system that will keep homebrew up to date. For now, please build from source.
 
 ```bash
 $ brew update
@@ -65,14 +58,11 @@ layman -a stefantalpalaru
 emerge dev-lang/pony
 ```
 
-A live ebuild is also available in the
-[overlay](https://github.com/stefantalpalaru/gentoo-overlay)
-(dev-lang/pony-9999) and for Vim users there's app-vim/pony-syntax.
+A live ebuild is also available in the [overlay](https://github.com/stefantalpalaru/gentoo-overlay) (dev-lang/pony-9999) and for Vim users there's app-vim/pony-syntax.
 
 ### Other distributions
 
-We're transitioning to a new binary release system. For now, please build from 
-source.
+We're transitioning to a new binary release system. For now, please build from source.
 
 ## Windows
 
@@ -83,23 +73,17 @@ You will need to build from source.
 ## Building on Linux
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
 
-First, install LLVM using your package manager. You may need to install zlib, 
-ncurses, pcre2, and ssl as well. Instructions for some specific distributions follow.
+First, install LLVM using your package manager. You may need to install zlib, ncurses, pcre2, and ssl as well. Instructions for some specific distributions follow.
 
-APT packages for LLVM 3.7 and 3.8, for Debian and Ubuntu, are provided by the 
-LLVM build server.
+APT packages for LLVM 3.7 and 3.8, for Debian and Ubuntu, are provided by the LLVM build server.
 
-Please follow the instructions at http://llvm.org/apt/ for installing the GPG 
-keys and packages for your distribution.
+Please follow the instructions at http://llvm.org/apt/ for installing the GPG keys and packages for your distribution.
 
 #### Notes:
 
-On Ubuntu,
-```apt-get install llvm-dev``` installs LLVM-3.6.
+On Ubuntu, `apt-get install llvm-dev` installs LLVM-3.6.
 
-When installing the full set of LLVM packages, the ```apt-get install``` 
-instructions include the ```clang-modernize``` package. This should be changed 
-to ```clang-tidy``` due to a recent name change.
+When installing the full set of LLVM packages, the `apt-get install` instructions include the `clang-modernize` package. This should be changed to `clang-tidy` due to a recent name change.
 
 
 ### Debian Jessie
@@ -111,8 +95,7 @@ deb http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main
 deb-src http://llvm.org/apt/jessie/ llvm-toolchain-jessie-3.8 main
 ```
 
-Install the LLVM toolchain public GPG key, update `apt` and install
-packages:
+Install the LLVM toolchain public GPG key, update `apt` and install packages:
 
 ```bash
 $ wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key|sudo apt-key add -
@@ -121,9 +104,7 @@ $ sudo apt-get install make gcc g++ git zlib1g-dev libncurses5-dev \
                        libssl-dev llvm-3.8-dev
 ```
 
-Debian Jessie and some other Linux distributions don't include pcre2 in their
-package manager. pcre2 is used by the Pony regex package. To download and
-build pcre2 from source:
+Debian Jessie and some other Linux distributions don't include pcre2 in their package manager. pcre2 is used by the Pony regex package. To download and build pcre2 from source:
 
 ```bash
 $ wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
@@ -148,9 +129,7 @@ $ sudo apt-get install build-essential git \
                        zlib1g-dev libncurses5-dev libssl-dev
 ```
 
-Ubuntu and some other Linux distributions don't include pcre2 in their
-package manager. pcre2 is used by the Pony regex package. To download and
-build pcre2 from source:
+Ubuntu and some other Linux distributions don't include pcre2 in their package manager. pcre2 is used by the Pony regex package. To download and build pcre2 from source:
 
 ```bash
 $ wget ftp://ftp.csx.cam.ac.uk/pub/software/programming/pcre/pcre2-10.21.tar.bz2
@@ -186,9 +165,7 @@ $ gmake config=release
 $ ./build/release/ponyc examples/helloworld
 ```
 
-Please note that on 32-bit X86, using LLVM 3.7 or 3.8 on FreeBSD currently
-produces executables that don't run. Please use LLVM 3.6. 64-bit X86 does not
-have this problem, and works fine with LLVM 3.7 and 3.8.
+Please note that on 32-bit X86, using LLVM 3.7 or 3.8 on FreeBSD currently produces executables that don't run. Please use LLVM 3.6. 64-bit X86 does not have this problem, and works fine with LLVM 3.7 and 3.8.
 
 ## Building on Mac OS X
 [![Linux and OS X](https://travis-ci.org/ponylang/ponyc.svg?branch=master)](https://travis-ci.org/ponylang/ponyc)
@@ -216,28 +193,24 @@ $ ./build/release/ponyc examples/helloworld
 ## Building on Windows
 [![Windows](https://ci.appveyor.com/api/projects/status/kckam0f1a1o0ly2j?svg=true)](https://ci.appveyor.com/project/sylvanc/ponyc)
 
-The LLVM prebuilt binaries for Windows do NOT include the LLVM development
-tools and libraries. Instead, you will have to build and install LLVM 3.7 or
-3.8 from source. You will need to make sure that the path to LLVM/bin (location
-of llvm-config) is in your PATH variable.
+The LLVM prebuilt binaries for Windows do NOT include the LLVM development tools and libraries. Instead, you will have to build and install LLVM 3.7 or 3.8 from source. You will need to make sure that the path to LLVM/bin (location of llvm-config) is in your PATH variable.
 
-LLVM recommends using the GnuWin32 unix tools; your mileage may vary using
-MSYS or Cygwin.
+LLVM recommends using the GnuWin32 unix tools; your mileage may vary using MSYS or Cygwin.
 
 - Install GnuWin32 using the [GetGnuWin32](http://getgnuwin32.sourceforge.net/)
-  tool.
+ tool.
 - Install [Python](https://www.python.org/downloads/release/python-351/) (3.5 or
-  2.7).
+ 2.7).
 - Install [CMake](https://cmake.org/download/).
 - Get the LLVM source (e.g. 3.7.1 is
-  at [3.7.1](http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz)).
+ at [3.7.1](http://llvm.org/releases/3.7.1/llvm-3.7.1.src.tar.xz)).
 - Make sure you have VS2015 with the C++ tools installed.
 - Generate LLVM VS2015 configuration with CMake. You can use the GUI to
-  configure and generate the VS projects; make sure you use the 64-bit
-  generator (**Visual Studio 14 2015 Win64**), and set the
-  `CMAKE_INSTALL_PREFIX` to where you want LLVM to live.
+ configure and generate the VS projects; make sure you use the 64-bit
+ generator (**Visual Studio 14 2015 Win64**), and set the
+ `CMAKE_INSTALL_PREFIX` to where you want LLVM to live.
 - Open the LLVM.sln in Visual Studio 2015 and build the INSTALL project in
-  the LLVM solution in Release mode.
+ the LLVM solution in Release mode.
 
 Building Pony requires [Premake 5](https://premake.github.io).
 
@@ -247,16 +220,14 @@ Building Pony requires [Premake 5](https://premake.github.io).
   solution.
 - Build ponyc.sln in Release mode.
 
-In order to run the pony compiler, you'll need a few libraries in your
-environment (pcre2, libssl, libcrypto).
+In order to run the pony compiler, you'll need a few libraries in your environment (pcre2, libssl, libcrypto).
 
-There is a third-party utility that will get the libraries and set up your
-environment:
+There is a third-party utility that will get the libraries and set up your environment:
 
 - Install [7-Zip](http://www.7-zip.org/a/7z1514-x64.exe), make sure it's in
-  your PATH.
+ your PATH.
 - Open a **VS2015 x64 Native Tools Command Prompt** (things will not work
-  correctly otherwise!) and run:
+ correctly otherwise!) and run:
 
 ```
 > git clone git@github.com:kulibali/ponyc-windows-libs.git
@@ -277,16 +248,13 @@ Now you can run the pony compiler and tests:
 
 ## Building with link-time optimisation (LTO)
 
-You can enable LTO when building the compiler in release mode. There are
-slight differences between platforms so you'll need to do a manual setup.
-LTO is enabled by setting `lto` to `yes` in the build command line:
+You can enable LTO when building the compiler in release mode. There are slight differences between platforms so you'll need to do a manual setup. LTO is enabled by setting `lto` to `yes` in the build command line:
 
 ```bash
 $ make config=release lto=yes
 ```
 
-If the build fails, you have to specify the LTO plugin for your compiler
-in the `LTO_PLUGIN` variable. For example:
+If the build fails, you have to specify the LTO plugin for your compiler in the `LTO_PLUGIN` variable. For example:
 
 ```bash
 $ make config=release LTO_PLUGIN=/usr/lib/LLVMgold.so
@@ -299,7 +267,6 @@ LTO is enabled by default on OSX.
 
 ## VirtualBox
 
-Pony binaries can trigger illegal instruction errors under VirtualBox 4.x, for
-at least the x86_64 platform and possibly others.
+Pony binaries can trigger illegal instruction errors under VirtualBox 4.x, for at least the x86_64 platform and possibly others.
 
 Use VirtualBox 5.x to avoid possible problems.

--- a/getting-started/what-you-need.md
+++ b/getting-started/what-you-need.md
@@ -1,50 +1,33 @@
 # What You Need
 
-To get started, you'll need a text editor and the 
-[ponyc](https://github.com/ponylang/ponyc) compiler. That's it.
+To get started, you'll need a text editor and the [ponyc](https://github.com/ponylang/ponyc) compiler. That's it.
 
 ## A text editor
 
-While you can write code using any editor, it's nice to use one with some 
-support for the language. Here are some:
+While you can write code using any editor, it's nice to use one with some support for the language. Here are some:
 
-* [Sublime Text](http://www.sublimetext.com/). There's a 
-[Pony Language](https://packagecontrol.io/packages/Pony%20Language) package.
-* [Atom](https://atom.io/). There's a 
-[language-pony](https://atom.io/packages/language-pony) package.
-* [Emacs](https://www.gnu.org/software/emacs/emacs.html). There's a 
-[ponylang-mode](https://github.com/seantallen/ponylang-mode).
-* [Vim](http://www.vim.org). There's a [
-pony-vim-syntax](https://github.com/dleonard0/pony-vim-syntax) plugin. 
-Install `pony` with `vim-plug` or `pathogen`.
-* [Microsoft Visual Studio](http://www.visualstudio.com/). There's a 
-[VS-pony](https://github.com/CausalityLtd/VS-pony) plugin.
-* [BBEdit](http://www.barebones.com/products/bbedit/). There's a 
-[bbedit-pony](https://github.com/TheMue/bbedit-pony) module.
+* [Sublime Text](http://www.sublimetext.com/). There's a [Pony Language](https://packagecontrol.io/packages/Pony%20Language) package.
+* [Atom](https://atom.io/). There's a [language-pony](https://atom.io/packages/language-pony) package.
+* [Emacs](https://www.gnu.org/software/emacs/emacs.html). There's a [ponylang-mode](https://github.com/seantallen/ponylang-mode).
+* [Vim](http://www.vim.org). There's a [ pony-vim-syntax](https://github.com/dleonard0/pony-vim-syntax) plugin. Install `pony` with `vim-plug` or `pathogen`.
+* [Microsoft Visual Studio](http://www.visualstudio.com/). There's a [VS-pony](https://github.com/CausalityLtd/VS-pony) plugin.
+* [BBEdit](http://www.barebones.com/products/bbedit/). There's a [bbedit-pony](https://github.com/TheMue/bbedit-pony) module.
 
-If you have a favourite editor that isn't supported, we'd love to help you
-build a Pony package for it.
+If you have a favourite editor that isn't supported, we'd love to help you build a Pony package for it.
 
 ## The compiler
 
-Pony is a _compiled_ language, rather than an _interpreted_ one. In fact, it 
-goes even further: Pony is an _ahead-of-time_ (AOT) compiled language, rather 
-than a _just-in-time_ (JIT) compiled language.
+Pony is a _compiled_ language, rather than an _interpreted_ one. In fact, it goes even further: Pony is an _ahead-of-time_ (AOT) compiled language, rather than a _just-in-time_ (JIT) compiled language.
 
-What this means is that once you build your program, you can run it over and 
-over again without needing a compiler or a virtual machine or anything else. 
-It's a complete program, all on its own.
+What this means is that once you build your program, you can run it over and over again without needing a compiler or a virtual machine or anything else. It's a complete program, all on its own.
 
-But it also means you need to build your program before you can run it. In an 
-interpreted language or a JIT compiled language, you tend to do things like 
-this to run your program:
+But it also means you need to build your program before you can run it. In an interpreted language or a JIT compiled language, you tend to do things like this to run your program:
 
 ```bash
 $ python helloworld.py
 ```
 
-Or maybe you put a __shebang__ in your program (like `#!/usr/bin/env python`), 
-then `chmod` to set the executable bit, and then do:
+Or maybe you put a __shebang__ in your program (like `#!/usr/bin/env python`), then `chmod` to set the executable bit, and then do:
 
 ```bash
 $ ./helloworld.py
@@ -60,9 +43,7 @@ If you are in the same directory as your program, you can just do:
 $ ponyc
 ```
 
-That tells the Pony compiler that your current working directory contains your 
-source code, and to please compile it. If your source code is in some other 
-directory, you can tell ponyc where it is:
+That tells the Pony compiler that your current working directory contains your source code, and to please compile it. If your source code is in some other directory, you can tell ponyc where it is:
 
 ```bash
 $ ponyc path/to/my/code

--- a/packages/package-system.md
+++ b/packages/package-system.md
@@ -1,33 +1,20 @@
 # Package System
 
-Pony code is organised into __packages__. Each program and library is a single 
-package, possibly using other packages.
+Pony code is organised into __packages__. Each program and library is a single package, possibly using other packages.
 
 ## The package structure
 
-The package is the basic unit of code in Pony. It corresponds directly to a 
-directory in the file system, all Pony source files within that directory are 
-within that package. Note that this does not include files in any 
-sub-directories.
+The package is the basic unit of code in Pony. It corresponds directly to a directory in the file system, all Pony source files within that directory are within that package. Note that this does not include files in any sub-directories.
 
-Every source file is within exactly one package. Hence all Pony code is in 
-packages.
+Every source file is within exactly one package. Hence all Pony code is in packages.
 
-A package is usually split into several source files, although it does not have 
-to be. This is purely a convenience to allow better code organisation and the 
-compiler treats all the code within a package as if it were from a single file.
+A package is usually split into several source files, although it does not have to be. This is purely a convenience to allow better code organisation and the compiler treats all the code within a package as if it were from a single file.
 
 The package is the privacy boundary for types and methods. That is:
 
-1. Private types (those whose name starts with an underscore) can be used only 
-within the package in which they are defined.
-1. Private methods (those whose name starts with an underscore) can be called 
-only from code within the package in which they are defined.
+1. Private types (those whose name starts with an underscore) can be used only within the package in which they are defined.
+1. Private methods (those whose name starts with an underscore) can be called only from code within the package in which they are defined.
 
-It follows that all code within a package is assumed to know of, and trust, all 
-the rest of the code in the package.
+It follows that all code within a package is assumed to know of, and trust, all the rest of the code in the package.
 
-There is no such concept as a sub-package in Pony. For example the packages 
-"foo/bar" and "foo/bar/wombat" will, presumably, perform related tasks but they 
-are two independent packages. Package "foo/bar" does not contain package 
-"foo/bar/wombat" and neither has access to the private elements of the other.
+There is no such concept as a sub-package in Pony. For example the packages "foo/bar" and "foo/bar/wombat" will, presumably, perform related tasks but they are two independent packages. Package "foo/bar" does not contain package "foo/bar/wombat" and neither has access to the private elements of the other.

--- a/packages/standard-library.md
+++ b/packages/standard-library.md
@@ -1,16 +1,7 @@
 # Standard library
 
-The Pony standard library is a collection of packages that can each be used as 
-needed to provide a variety of functionality. For example the __files__ package 
-provides file access and the __collections__ package provides generic lists, 
-maps, sets and so on.
+The Pony standard library is a collection of packages that can each be used as needed to provide a variety of functionality. For example the __files__ package provides file access and the __collections__ package provides generic lists, maps, sets and so on.
 
-There is also a special package in the standard library called __builtin__. 
-This contains various types that the compiler has to treat specially and are so 
-common that all Pony code needs to know about them. All Pony source files have 
-an implicit `use "builtin"` command. This means all the types defined in the 
-package builtin are automatically available in the type namespace of all Pony 
-source files.
+There is also a special package in the standard library called __builtin__. This contains various types that the compiler has to treat specially and are so common that all Pony code needs to know about them. All Pony source files have an implicit `use "builtin"` command. This means all the types defined in the package builtin are automatically available in the type namespace of all Pony source files.
 
-Documentation for the standard library is 
-[available online](http://www.ponylang.org/ponyc/)
+Documentation for the standard library is [available online](http://www.ponylang.org/ponyc/)

--- a/packages/use-statement.md
+++ b/packages/use-statement.md
@@ -1,25 +1,16 @@
 # Use command
 
-To use a package in your code you need to have a __use__ command. This tells 
-the compiler to find the package you need and make the types defined in it 
-available to you. Every Pony file that needs to know about a type from a 
-package must have a use command for it.
+To use a package in your code you need to have a __use__ command. This tells the compiler to find the package you need and make the types defined in it available to you. Every Pony file that needs to know about a type from a package must have a use command for it.
 
-Use commands are a similar concept to Python and Java "import", C/C++ 
-"#include" and C# "using" commands, but not exactly the same. They come at the 
-beginning of Pony files and look like this:
+Use commands are a similar concept to Python and Java "import", C/C++ "#include" and C# "using" commands, but not exactly the same. They come at the beginning of Pony files and look like this:
 
 ```pony
 use "collections"
 ```
 
-This will find all of the publicly visible types defined in the _collections_ 
-package and add them to the type namespace of the file containing the use 
-command. These types are then available to use within that file, just as if 
-they were defined locally.
+This will find all of the publicly visible types defined in the _collections_ package and add them to the type namespace of the file containing the use command. These types are then available to use within that file, just as if they were defined locally.
 
-For example, the standard library contains the package _time_. This contains 
-the following definition (among others):
+For example, the standard library contains the package _time_. This contains the following definition (among others):
 
 ```pony
 primitive Time
@@ -38,11 +29,7 @@ class Foo
 
 ## Use names
 
-As we saw above the use command adds all the public types from a package into 
-the namespace of the using file. This means that using a package may define 
-type names that you want to use for your own types. Furthermore, if you use two 
-packages within a file they may both define the same type name, causing a clash 
-in your namespace. For example:
+As we saw above the use command adds all the public types from a package into the namespace of the using file. This means that using a package may define type names that you want to use for your own types. Furthermore, if you use two packages within a file they may both define the same type name, causing a clash in your namespace. For example:
 
 ```pony
 // In package A
@@ -59,14 +46,9 @@ class Bar
   var _x: Foo
 ```
 
-The declarations of _x is an error because we don't know which `Foo` is being 
-referred to. Actually using 'Foo' is not even required, simply using both 
-package A and package B is enough to cause an error here.
+The declarations of _x is an error because we don't know which `Foo` is being referred to. Actually using 'Foo' is not even required, simply using both package A and package B is enough to cause an error here.
 
-To avoid this problem the use command allows you to specify an alias. If you do 
-this then only that alias is put into your namespace. The types from the used 
-package can then be accessed using this alias as a qualifier. Our example now 
-becomes:
+To avoid this problem the use command allows you to specify an alias. If you do this then only that alias is put into your namespace. The types from the used package can then be accessed using this alias as a qualifier. Our example now becomes:
 
 ```pony
 // In package A
@@ -84,8 +66,7 @@ class Bar
   var _y: b.Foo  // The Foo from package B
 ```
 
-If you prefer you can give an alias to only one of the packages. `Foo` will 
-then still be added to your namespace referring to the unaliased package:
+If you prefer you can give an alias to only one of the packages. `Foo` will then still be added to your namespace referring to the unaliased package:
 
 ```pony
 // In package A
@@ -103,24 +84,13 @@ class Bar
   var _y: b.Foo  // The Foo from package B
 ```
 
-__Can I just specify the full package path and forget about the use command, 
-like I do in Java and C#?__ No, you can't do that in Pony. You can't refer to 
-one package based on a use command for another package and you can't use types 
-from a package without a use command for that package. Every package that you 
-want to use must have its own use command.
+__Can I just specify the full package path and forget about the use command, like I do in Java and C#?__ No, you can't do that in Pony. You can't refer to one package based on a use command for another package and you can't use types from a package without a use command for that package. Every package that you want to use must have its own use command.
 
-__Are there limits on the names I can use for an alias?__ Use alias names have 
-to start with a lower case letter. Other than that you can use whatever name 
-you want, as long as you're not using that name for any other purpose in your 
-file.
+__Are there limits on the names I can use for an alias?__ Use alias names have to start with a lower case letter. Other than that you can use whatever name you want, as long as you're not using that name for any other purpose in your file.
 
 ## Scheme indicators
 
-The string we give to a use command is known as the _specifier_. This consists 
-of a _scheme_ indicator and a _locator_, separated by a colon. The scheme 
-indicator tells the use command what we want it to do, for example the scheme 
-indicator for including a package is "package". If no colon is found within the 
-specifier string then the use command assumes you meant "package".
+The string we give to a use command is known as the _specifier_. This consists of a _scheme_ indicator and a _locator_, separated by a colon. The scheme indicator tells the use command what we want it to do, for example the scheme indicator for including a package is "package". If no colon is found within the specifier string then the use command assumes you meant "package".
 
 The following two use commands are exactly equivalent:
 
@@ -129,15 +99,11 @@ use "foo"
 use "package:foo"
 ```
 
-If you are using a locator string that includes a colon, for example an 
-absolute path in Windows, then you __have__ to include the "package" scheme 
-specifier:
+If you are using a locator string that includes a colon, for example an absolute path in Windows, then you __have__ to include the "package" scheme specifier:
 
 ```pony
 use "C:/foo/bar"  // Error, scheme "C" is unknown
 use "package:C:/foo/bar"  // OK
 ```
 
-To allow use commands to be portable across operating systems, and to avoid 
-confusion with escape characters, '/' should always be used as the path 
-separator in use commands, even on Windows.
+To allow use commands to be portable across operating systems, and to avoid confusion with escape characters, '/' should always be used as the path separator in use commands, even on Windows.

--- a/pattern-matching/as.md
+++ b/pattern-matching/as.md
@@ -1,31 +1,14 @@
 # As Operator
 
-The `as` operator in Pony has two related uses. First, it provides a
-safe way to increase the specificity of an object's type
-(casting). Second, it gives the programmer a way to specify the type
-of the items in an array literal.
+The `as` operator in Pony has two related uses. First, it provides a safe way to increase the specificity of an object's type (casting). Second, it gives the programmer a way to specify the type of the items in an array literal.
 
 ## Safely converting to a more specific type (casting)
 
-The `as` operator can be used to create a reference to an object with
-a more specific type than the given reference, if possible. This can
-be applied to types that are related through inheritance, as well as
-unions and intersections. This is done at runtime, and if it fails
-then an error is raised.
+The `as` operator can be used to create a reference to an object with a more specific type than the given reference, if possible. This can be applied to types that are related through inheritance, as well as unions and intersections. This is done at runtime, and if it fails then an error is raised.
 
-Let's look at an example. The `json` package provides a type called
-`JsonDoc` that can attempt to parse strings as fragments of JSON. The
-parsed value is stored in the `data` field of the object, and that
-field's type is the union `(F64 | I64 | Bool | None | String |
-JsonArray | JsonObject)`. So if there is a `JsonDoc` object referenced
-by `jsonDoc` then `jsonDoc.parse("42")` will store an `I64` equal to
-`42` in `jsonDoc.data`. If the programmer want to treat `jsonDoc.data`
-as an `I64` then they can get an `I64` reference to the data by using
-`jsonDoc.data as I64`.
+Let's look at an example. The `json` package provides a type called `JsonDoc` that can attempt to parse strings as fragments of JSON. The parsed value is stored in the `data` field of the object, and that field's type is the union `(F64 | I64 | Bool | None | String | JsonArray | JsonObject)`. So if there is a `JsonDoc` object referenced by `jsonDoc` then `jsonDoc.parse("42")` will store an `I64` equal to `42` in `jsonDoc.data`. If the programmer want to treat `jsonDoc.data` as an `I64` then they can get an `I64` reference to the data by using `jsonDoc.data as I64`.
 
-In the following program, the commandline arguments are parsed as
-Json. A running sum is kept of all of the arguments that can be parsed
-as `I64` numbers, and all other arguments are ignored.
+In the following program, the commandline arguments are parsed as Json. A running sum is kept of all of the arguments that can be parsed as `I64` numbers, and all other arguments are ignored.
 
 ```
 use "json"
@@ -43,30 +26,16 @@ actor Main
     env.out.print(jsonSum.string())
 ```
 
-When run with the arguments `2 and 4 et 7 y 15`, the program's output
-is `28`.
+When run with the arguments `2 and 4 et 7 y 15`, the program's output is `28`.
 
-The same thing can be done with interfaces, using `as` to create a
-reference to a more specific interface or class. Let's say, for
-example, that you have a library for doing things with rodents. It
-provides a `Rodent` interface which programmers can then use to create
-specific types of rodents.
+The same thing can be done with interfaces, using `as` to create a reference to a more specific interface or class. Let's say, for example, that you have a library for doing things with rodents. It provides a `Rodent` interface which programmers can then use to create specific types of rodents.
 
 ```pony
 interface Rodent
   fun wash(): String
 ```
 
-The programmer uses this library to create a `Wombat` and a `Capybara`
-class. But the `Capybara` class provides a new method, `swim()`, that
-is not part of the `Rodent` class. The programmer wants to store all
-of the rodents in an array, in order to carry out actions on groups of
-rodents. Now assume that when capybaras finish washing they want to go
-for a swim. The programmer can accomplish that by using `as` to
-attempt to use each `Rodent` object in the `Array[Rodent` as a
-`Capybara`. If this fails because the `Rodent` is not a `Capybara`,
-then an error is raised; the program can swallow this error and go on
-to the next item.
+The programmer uses this library to create a `Wombat` and a `Capybara` class. But the `Capybara` class provides a new method, `swim()`, that is not part of the `Rodent` class. The programmer wants to store all of the rodents in an array, in order to carry out actions on groups of rodents. Now assume that when capybaras finish washing they want to go for a swim. The programmer can accomplish that by using `as` to attempt to use each `Rodent` object in the `Array[Rodent` as a `Capybara`. If this fails because the `Rodent` is not a `Capybara`, then an error is raised; the program can swallow this error and go on to the next item.
 
 ```pony
 class Wombat is Rodent
@@ -89,15 +58,9 @@ actor Main
 
 ## Specify the type of items in an array literal
 
-The `as` operator can be used to tell the compiler what type to use
-for the items in an array literal. In many cases the compiler can
-infer the type, but sometimes it is ambiguous.
+The `as` operator can be used to tell the compiler what type to use for the items in an array literal. In many cases the compiler can infer the type, but sometimes it is ambiguous.
 
-For example, in the case of the following program, the method `foo`
-can take either an `Array[U32] ref` or an `Array[U64] ref` as an
-argument. If a literal array is passed as an argument to the method
-and no type is specified then the compiler cannot deduce the correct
-one because there are two equally valid ones.
+For example, in the case of the following program, the method `foo` can take either an `Array[U32] ref` or an `Array[U64] ref` as an argument. If a literal array is passed as an argument to the method and no type is specified then the compiler cannot deduce the correct one because there are two equally valid ones.
 
 ```
 actor Main
@@ -111,7 +74,4 @@ actor Main
     //   foo([1, 2, 3])
 ```
 
-The requested type must be a valid type for the items in the
-array. Since these types are checked at compile time they are
-guaranteed to work, so there is no need for the programmer to handle
-an error condition.
+The requested type must be a valid type for the items in the array. Since these types are checked at compile time they are guaranteed to work, so there is no need for the programmer to handle an error condition.

--- a/pattern-matching/case-functions.md
+++ b/pattern-matching/case-functions.md
@@ -1,17 +1,8 @@
 # Case Functions
 
-Case functions give the programmer a way to create different versions
-of a function; the case that is called is based on the arguments given
-when the function is called. As with `match` statements, the function
-can be selected by the value or the type of the arguments, and guard
-statements can be used for additional control. Different cases of a
-function have the same name and parameter list with the same number
-of arguments (though not necessarily the same parameter types or
-return types).
+Case functions give the programmer a way to create different versions of a function; the case that is called is based on the arguments given when the function is called. As with `match` statements, the function can be selected by the value or the type of the arguments, and guard statements can be used for additional control. Different cases of a function have the same name and parameter list with the same number of arguments (though not necessarily the same parameter types or return types).
 
-A classic example of this type of function is the a recursive function
-with a base case. For example, the factorial of `n` can be found using
-the following function:
+A classic example of this type of function is the a recursive function with a base case. For example, the factorial of `n` can be found using the following function:
 
 ```
        / f(0) => 1
@@ -19,13 +10,7 @@ f(n) = |
        \ f(n) => n * f(n - 1)
 ```
 
-This could be implemented in Pony with an `if` statement to check
-whether to return 1 or make the recursive call, but it can also be
-implemented with a set of case functions. The `fac_case` function uses
-parameter matching to dispatch based on whether or not the argument is
-`0`, while the `fac_guard` function uses a guard statement to test the
-incoming argument. In both functions there is a default case in which
-there are no match parameters nor guard statements.
+This could be implemented in Pony with an `if` statement to check whether to return 1 or make the recursive call, but it can also be implemented with a set of case functions. The `fac_case` function uses parameter matching to dispatch based on whether or not the argument is `0`, while the `fac_guard` function uses a guard statement to test the incoming argument. In both functions there is a default case in which there are no match parameters nor guard statements.
 
 ```pony
 primitive Factorial
@@ -62,31 +47,11 @@ actor Main
     end
 ```
 
-Note that in the example above the return values of `fac_case(n)` and
-`fac_guard(n)` must explicitly be cast as `U64`. This is because the
-compiler does not check to make sure that all cases can be matched and
-instead creates an implicit base case that returns None if no match
-occurs. Therefore, if `T` is the union of all of the explicit return
-types for a case function, then the implied type of the function is
-actually `(T | None)`.
+Note that in the example above the return values of `fac_case(n)` and `fac_guard(n)` must explicitly be cast as `U64`. This is because the compiler does not check to make sure that all cases can be matched and instead creates an implicit base case that returns None if no match occurs. Therefore, if `T` is the union of all of the explicit return types for a case function, then the implied type of the function is actually `(T | None)`.
 
-The parameter types for different cases do not have to match, but each
-case of the same function must have the same number of parameters, and
-the parameters must have the same names in each case of the
-function. Also, different cases of the same function can have
-different return types; as mentioned above, the return types are
-combined as a union (along with None) to create the final type for the
-function. The type and name for each parameter must be specified
-somewhere in the combination of case functions, though not necessarily
-all in the same case (see the `x`, `f`, and `b` paramters in the
-`_fizz_buzz` method below).
+The parameter types for different cases do not have to match, but each case of the same function must have the same number of parameters, and the parameters must have the same names in each case of the function. Also, different cases of the same function can have different return types; as mentioned above, the return types are combined as a union (along with None) to create the final type for the function. The type and name for each parameter must be specified somewhere in the combination of case functions, though not necessarily all in the same case (see the `x`, `f`, and `b` paramters in the `_fizz_buzz` method below).
 
-In the following implementation of
-[FizzBuzz](http://c2.com/cgi/wiki?FizzBuzzTest) `fizz_buzz` is a case
-function that takes either a `U64` or a `Range[U64]`, and consequently
-returns either a `String` or an `Array[String]`, while the helper
-function `_fizz_buzz` is a case function that determines what to
-return by matching the arguments that are passed to it:
+In the following implementation of [FizzBuzz](http://c2.com/cgi/wiki?FizzBuzzTest) `fizz_buzz` is a case function that takes either a `U64` or a `Range[U64]`, and consequently returns either a `String` or an `Array[String]`, while the helper function `_fizz_buzz` is a case function that determines what to return by matching the arguments that are passed to it:
 
 ```
 use "collections"
@@ -118,8 +83,4 @@ actor Main
     end
 ```
 
-Case functions can improve readability by making it clear that certain
-argument will cause certain code paths to execute. They are currently
-implemented as sugar that translates to a `match` statement, so there
-is no more overhead than if the programmer had written the `match`
-themselves.
+Case functions can improve readability by making it clear that certain argument will cause certain code paths to execute. They are currently implemented as sugar that translates to a `match` statement, so there is no more overhead than if the programmer had written the `match` themselves.

--- a/pattern-matching/index.md
+++ b/pattern-matching/index.md
@@ -1,3 +1,3 @@
 # Chapter 6: Pattern Matching
 
-In this chapter, you'll learn how to Pony's two types of matching work. 
+In this chapter, you'll learn how to Pony's two types of matching work.

--- a/pattern-matching/match.md
+++ b/pattern-matching/match.md
@@ -1,9 +1,6 @@
 # Match Expressions
 
-If we want to compare an expression to a value then we use an `if`. But if we 
-want to compare an expression to a lot of values this gets very tedious. Pony 
-provides a powerful pattern matching facility, combining matching on values and 
-types, without any special code required.
+If we want to compare an expression to a value then we use an `if`. But if we want to compare an expression to a lot of values this gets very tedious. Pony provides a powerful pattern matching facility, combining matching on values and types, without any special code required.
 
 ## Matching: the basics
 
@@ -21,45 +18,23 @@ end
 
 If you're used to functional languages this should be very familiar.
 
-For those readers more familiar with the C and Java family of languages, think 
-of this like a switch statement. But you can switch on values other than just 
-integers, like Strings. In fact you can switch on any type that provides a 
-comparison function, including your own classes. And you can also switch on the 
-runtime type of an expression.
+For those readers more familiar with the C and Java family of languages, think of this like a switch statement. But you can switch on values other than just integers, like Strings. In fact you can switch on any type that provides a comparison function, including your own classes. And you can also switch on the runtime type of an expression.
 
-A match starts with the keyword `match`, followed by the expression to match, 
-which is known as the match __operand__. In this example the operand is just 
-the variable `x`, but it can be any expression.
+A match starts with the keyword `match`, followed by the expression to match, which is known as the match __operand__. In this example the operand is just the variable `x`, but it can be any expression.
 
-Most of the match expression consists of a series of __cases__ that we match 
-against. Each case consists of a pipe symbol ('|'), the __pattern__ to match 
-against, an arrow ('=>') and the expression to evaluate if the case matches.
+Most of the match expression consists of a series of __cases__ that we match against. Each case consists of a pipe symbol ('|'), the __pattern__ to match against, an arrow ('=>') and the expression to evaluate if the case matches.
 
-We go through the cases one by one until we find one that matches. (Actually, 
-in practice the compiler is a lot more intelligent than that and uses a 
-combination of sequential checks and jump tables to be as efficient as 
-possible.)
+We go through the cases one by one until we find one that matches. (Actually, in practice the compiler is a lot more intelligent than that and uses a combination of sequential checks and jump tables to be as efficient as possible.)
 
-Note that each match case has an expression to evaluate and these are all 
-independent. There is no "fall through" between cases as there is in languages 
-such as C.
+Note that each match case has an expression to evaluate and these are all independent. There is no "fall through" between cases as there is in languages such as C.
 
-If the value produced by the match expression isn't used then the cases can 
-omit the arrow and expression to evaluate. This can be useful for excluding 
-specific cases before a more general case.
+If the value produced by the match expression isn't used then the cases can omit the arrow and expression to evaluate. This can be useful for excluding specific cases before a more general case.
 
 ### Else cases
 
-As with all Pony control structures the else case for a match expression is 
-used if we have no other value, i.e. if none of our cases match. The else case, 
-if there is one, __must__ come at the end of the match, after all of the 
-specific cases.
+As with all Pony control structures the else case for a match expression is used if we have no other value, i.e. if none of our cases match. The else case, if there is one, __must__ come at the end of the match, after all of the specific cases.
 
-If the value the match expression results in is used then you need to have an 
-else case, even if it can never actually be reached. If you omit it a default 
-will be added which evaluates to `None`. The compiler currently isn't clever 
-enough to spot when the other cases are exhaustive and so the else is not 
-needed. This will be changed later.
+If the value the match expression results in is used then you need to have an else case, even if it can never actually be reached. If you omit it a default will be added which evaluates to `None`. The compiler currently isn't clever enough to spot when the other cases are exhaustive and so the else is not needed. This will be changed later.
 
 ## Matching on values
 
@@ -77,24 +52,20 @@ fun f(x: U32): String =>
   end
 ```
 
-For value matching the pattern is simply the value we want to match to, just 
-like a C switch statement. The case with the same value as the operand wins and 
-we use its expression.
+For value matching the pattern is simply the value we want to match to, just like a C switch statement. The case with the same value as the operand wins and we use its expression.
 
-The compiler calls the eq() function on the operand, passing the pattern as the 
-argument. This means that you can use your own types as match operands and 
-patterns, as long as you define an eq() function.
+The compiler calls the eq() function on the operand, passing the pattern as the argument. This means that you can use your own types as match operands and patterns, as long as you define an eq() function.
 
 ```pony
 class Foo
   var _x: U32
-  
+
   new create(x: U32) =>
     _x = x
 
   fun eq(that: Foo): Bool =>
     _x == that._x
-	
+
 actor Main
   fun f(x: Foo): String =>
     match x
@@ -109,10 +80,7 @@ actor Main
 
 ## Matching on type and value
 
-Matching on value is fine if the match operand and case patterns have all the 
-same type. However match can cope with multiple different types. Each case 
-pattern is first checked to see if it is the same type as the runtime type of 
-the operand. Only then will the values be compared.
+Matching on value is fine if the match operand and case patterns have all the same type. However match can cope with multiple different types. Each case pattern is first checked to see if it is the same type as the runtime type of the operand. Only then will the values be compared.
 
 ```pony
 fun f(x: (U32 | String | None)): String =>
@@ -126,25 +94,15 @@ fun f(x: (U32 | String | None)): String =>
   end
 ```
 
-In many languages using runtime type information is very expensive and so it is 
-generally avoided whenever possible.
+In many languages using runtime type information is very expensive and so it is generally avoided whenever possible.
 
-In Pony it's cheap. Really cheap. Pony's "whole program" approach to 
-compilation means the compiler can work out as much as possible at compile 
-time. The runtime cost of each type check is generally a single pointer 
-comparison. Plus of course, any checks which can be fully determined at compile 
-time are. So for up casts there's no runtime cost at all.
+In Pony it's cheap. Really cheap. Pony's "whole program" approach to compilation means the compiler can work out as much as possible at compile time. The runtime cost of each type check is generally a single pointer comparison. Plus of course, any checks which can be fully determined at compile time are. So for up casts there's no runtime cost at all.
 
 ## Captures
 
-Sometimes you want to be able to match on type, for any value of that type. For 
-this you use a __capture__. This defines a local variable, valid only within 
-the case, containing the value of the operand. If the operand is not of the 
-specified type then the case doesn't match.
+Sometimes you want to be able to match on type, for any value of that type. For this you use a __capture__. This defines a local variable, valid only within the case, containing the value of the operand. If the operand is not of the specified type then the case doesn't match.
 
-Captures look just like variable declarations within the pattern. Like normal 
-variables they can be declared as var or let. If you're not going to reassign 
-them within the case expression it is good practice to use let.
+Captures look just like variable declarations within the pattern. Like normal variables they can be declared as var or let. If you're not going to reassign them within the case expression it is good practice to use let.
 
 ```pony
 fun f(x: (U32 | String | None)): String =>
@@ -159,14 +117,11 @@ fun f(x: (U32 | String | None)): String =>
   end
 ```
 
-__Can I omit the type from a capture, like I can from a local variable?__ 
-Unfortunately no. Since we match on type and value the compiler has to know 
-what type the pattern is, so it can't be inferred.
+__Can I omit the type from a capture, like I can from a local variable?__ Unfortunately no. Since we match on type and value the compiler has to know what type the pattern is, so it can't be inferred.
 
 ## Matching tuples
 
-If you want to match on more than one operand at once then you can simply use a 
-tuple. Cases will only match if __all__ the tuple elements match.
+If you want to match on more than one operand at once then you can simply use a tuple. Cases will only match if __all__ the tuple elements match.
 
 ```pony
 fun f(x: (String | None), y: U32): String =>
@@ -180,10 +135,7 @@ fun f(x: (String | None), y: U32): String =>
   end
 ```
 
-__Do I have to specify all the elements in a tuple?__ No you don't. Any tuple 
-elements in a pattern can be marked as "don't care" by using an underscore 
-('_'). The first and fourth cases in our example don't actually care about the 
-U32 element, so we can ignore it.
+__Do I have to specify all the elements in a tuple?__ No you don't. Any tuple elements in a pattern can be marked as "don't care" by using an underscore ('_'). The first and fourth cases in our example don't actually care about the U32 element, so we can ignore it.
 
 ```pony
 fun f(x: (String | None), y: U32): String =>
@@ -199,16 +151,11 @@ fun f(x: (String | None), y: U32): String =>
 
 ## Guards
 
-In addition to matching on types and values each case in a match can also have 
-a guard condition. This is simply an expression, evaluated __after__ type and 
-value matching has occurred, that must give the value true for the case to 
-match. If the guard is false then the case doesn't match and we move onto the 
-next in the usual way.
+In addition to matching on types and values each case in a match can also have a guard condition. This is simply an expression, evaluated __after__ type and value matching has occurred, that must give the value true for the case to match. If the guard is false then the case doesn't match and we move onto the next in the usual way.
 
 Guards are introduced with the `if` keyword (_was `where` until 0.2.1_).
 
-A guard expression may use any captured variables from that case, which allows 
-for handling ranges and complex functions.
+A guard expression may use any captured variables from that case, which allows for handling ranges and complex functions.
 
 ```pony
 fun f(x: (String | None), y: U32): String =>

--- a/testing/index.md
+++ b/testing/index.md
@@ -1,6 +1,3 @@
 # Chapter 9: Testing
 
-Unto all code, good or bad, comes the needs to test it. Verification that our
-code does what we expect is very important. Over the last 20 years, there has
-been an explosion in different testing techniques and tools. This chapter will
-get you going with PonyTest, the current Pony testing tool.
+Unto all code, good or bad, comes the needs to test it. Verification that our code does what we expect is very important. Over the last 20 years, there has been an explosion in different testing techniques and tools. This chapter will get you going with PonyTest, the current Pony testing tool.

--- a/testing/ponytest.md
+++ b/testing/ponytest.md
@@ -1,24 +1,16 @@
 # Testing with PonyTest
 
-PonyTest is Pony's unit testing framework. It is designed to be as simple as
-possible to use, both for the unit test writer and the user running
-the tests.
-. 
-Each unit test is a class, with a single test function. By default all tests
-run concurrently.
+PonyTest is Pony's unit testing framework. It is designed to be as simple as possible to use, both for the unit test writer and the user running the tests.
 
-Each test run is provided with a helper object. This provides logging and
-assertion functions. By default log messages are only shown for tests that
-fail.
+Each unit test is a class, with a single test function. By default all tests run concurrently.
 
-When any assertion function fails the test is counted as a fail. However, tests
-can also indicate failure by raising an error in the test function.
+Each test run is provided with a helper object. This provides logging and assertion functions. By default log messages are only shown for tests that fail.
+
+When any assertion function fails the test is counted as a fail. However, tests can also indicate failure by raising an error in the test function.
 
 ## Example program
 
-To use PonyTest simply write a class for each test and a TestList type that
-tells the PonyTest object about the tests. Typically the TestList will be Main
-for the package.
+To use PonyTest simply write a class for each test and a TestList type that tells the PonyTest object about the tests. Typically the TestList will be Main for the package.
 
 The following is a complete program with 2 trivial tests.
 
@@ -48,34 +40,21 @@ class iso _TestSub is UnitTest
   fun apply(h: TestHelper) =>
     h.assert_eq[U32](2, 4 - 2)
 ```
+ The make() constructor is not needed for this example. However, it allows for easy aggregation of tests (see below) so it is recommended that all test Mains provide it.
 
-The make() constructor is not needed for this example. However, it allows for
-easy aggregation of tests (see below) so it is recommended that all test Mains
-provide it.
-
-Main.create() is called only for program invocations on the current package.
-Main.make() is called during aggregation. If so desired extra code can be added
-to either of these constructors to perform additional tasks.
+Main.create() is called only for program invocations on the current package. Main.make() is called during aggregation. If so desired extra code can be added to either of these constructors to perform additional tasks.
 
 ## Test names
 
-Tests are identified by names, which are used when printing test results and on
-the command line to select which tests to run. These names are independent of
-the names of the test classes in the Pony source code.
+Tests are identified by names, which are used when printing test results and on the command line to select which tests to run. These names are independent of the names of the test classes in the Pony source code.
 
-Arbitrary strings can be used for these names, but for large projects it is
-strongly recommended to use a hierarchical naming scheme to make it easier to
-select groups of tests.
+Arbitrary strings can be used for these names, but for large projects it is strongly recommended to use a hierarchical naming scheme to make it easier to select groups of tests.
 
 ## Aggregation
 
-Often it is desirable to run a collection of unit tests from multiple different
-source files. For example, if several packages within a bundle each have their
-own unit tests it may be useful to run all tests for the bundle together.
+Often it is desirable to run a collection of unit tests from multiple different source files. For example, if several packages within a bundle each have their own unit tests it may be useful to run all tests for the bundle together.
 
-This can be achieved by writing an aggregate test list class, which calls the
-list function for each package. The following is an example that aggregates the
-tests from packages `foo` and `bar`.
+This can be achieved by writing an aggregate test list class, which calls the list function for each package. The following is an example that aggregates the tests from packages `foo` and `bar`.
 
 ```pony
 use "ponytest"
@@ -94,79 +73,44 @@ actor Main is TestList
     bar.Main.make().tests(test)
 ```
 
-Aggregate test classes may themselves be aggregated. Every test list class may
-contain any combination of its own tests and aggregated lists.
+Aggregate test classes may themselves be aggregated. Every test list class may contain any combination of its own tests and aggregated lists.
 
 ## Long tests
 
-Simple tests run within a single function. When that function exits, either
-returning or raising an error, the test is complete. This is not viable for
-tests that need to use actors.
+Simple tests run within a single function. When that function exits, either returning or raising an error, the test is complete. This is not viable for tests that need to use actors.
 
-Long tests allow for delayed completion. Any test can call long_test() on its
-TestHelper to indicate that it needs to keep running. When the test is finally
-complete it calls complete() on its TestHelper.
+Long tests allow for delayed completion. Any test can call long_test() on its TestHelper to indicate that it needs to keep running. When the test is finally complete it calls complete() on its TestHelper.
 
-The complete() function takes a Bool parameter to specify whether the test was
-a success. If any asserts fail then the test will be considered a failure
-regardless of the value of this parameter. However, complete() must still be
-called.
+The complete() function takes a Bool parameter to specify whether the test was a success. If any asserts fail then the test will be considered a failure regardless of the value of this parameter. However, complete() must still be called.
 
-Since failing tests may hang, a timeout must be specified for each long test.
-When the test function exits a timer is started with the specified timeout. If
-this timer fires before complete() is called the test is marked as a failure
-and the timeout is reported.
+Since failing tests may hang, a timeout must be specified for each long test. When the test function exits a timer is started with the specified timeout. If this timer fires before complete() is called the test is marked as a failure and the timeout is reported.
 
-On a timeout the timed_out() function is called on the unit test object. This
-should perform whatever test specific tidy up is required to allow the program
-to exit. There is no need to call complete() if a timeout occurs, although it
-is not an error to do so.
+On a timeout the timed_out() function is called on the unit test object. This should perform whatever test specific tidy up is required to allow the program to exit. There is no need to call complete() if a timeout occurs, although it is not an error to do so.
 
-Note that the timeout is only relevant when a test hangs and would otherwise
-prevent the test program from completing. Setting a very long timeout on tests
-that should not be able to hang is perfectly acceptable and will not make the
-test take any longer if successful.
+Note that the timeout is only relevant when a test hangs and would otherwise prevent the test program from completing. Setting a very long timeout on tests that should not be able to hang is perfectly acceptable and will not make the test take any longer if successful.
 
-Timeouts should not be used as the standard method of detecting if a test has
-failed.
+Timeouts should not be used as the standard method of detecting if a test has failed.
 
 ## Exclusion groups
 
-By default all tests are run concurrently. This may be a problem for some
-tests, eg if they manipulate an external file or use a system resource. To fix
-this issue any number of tests may be put into an exclusion group.
+By default all tests are run concurrently. This may be a problem for some tests, eg if they manipulate an external file or use a system resource. To fix this issue any number of tests may be put into an exclusion group.
 
 No tests that are in the same exclusion group will be run concurrently.
 
-Exclusion groups are identified by name, arbitrary strings may be used.
-Multiple exclusion groups may be used and tests in different groups may run
-concurrently. Tests that do not specify an exclusion group may be run
-concurrently with any other tests.
+Exclusion groups are identified by name, arbitrary strings may be used. Multiple exclusion groups may be used and tests in different groups may run concurrently. Tests that do not specify an exclusion group may be run concurrently with any other tests.
 
-The command line option "--sequential" prevents any tests from running
-concurrently, regardless of exclusion groups. This is intended for debugging
-rather than standard use.
+The command line option "--sequential" prevents any tests from running concurrently, regardless of exclusion groups. This is intended for debugging rather than standard use.
 
 ## Tear down
 
-Each unit test object may define a tear_down() function. This is called after
-the test has finished to allow tearing down of any complex environment that had
-to be set up for the test.
+Each unit test object may define a tear_down() function. This is called after the test has finished to allow tearing down of any complex environment that had to be set up for the test.
 
-The tear_down() function is called for each test regardless of whether it
-passed or failed. If a test times out tear_down() will be called after
-timed_out() returns.
+The tear_down() function is called for each test regardless of whether it passed or failed. If a test times out tear_down() will be called after timed_out() returns.
 
-When a test is in an exclusion group, the tear_down() call is considered part
-of the tests run. The next test in the exclusion group will not start until
-after tear_down() returns on the current test.
+When a test is in an exclusion group, the tear_down() call is considered part of the tests run. The next test in the exclusion group will not start until after tear_down() returns on the current test.
 
-The test's TestHelper is handed to tear_down() and it is permitted to log
-messages and call assert functions during tear down.
+The test's TestHelper is handed to tear_down() and it is permitted to log messages and call assert functions during tear down.
 
 ## Additional resources
 
-You can learn more about PonyTest specifics by checking out the 
-[API documentation](http://www.ponylang.org/ponyc/ponytest--index/). There's
-also a [testing section](http://patterns.ponylang.org/testing/index.html) in the
-[Pony Patterns](http://patterns.ponylang.org/) book.
+You can learn more about PonyTest specifics by checking out the [API documentation](http://www.ponylang.org/ponyc/ponytest--index/). There's also a [testing section](http://patterns.ponylang.org/testing/index.html) in the [Pony Patterns](http://patterns.ponylang.org/) book.

--- a/types/actors.md
+++ b/types/actors.md
@@ -1,30 +1,18 @@
 # Actors
 
-An __actor__ is similar to a __class__, but with one critical difference: an 
-actor can have __behaviours__.
+An __actor__ is similar to a __class__, but with one critical difference: an actor can have __behaviours__.
 
 ## Behaviours
 
-A __behaviour__ is like a __function__, except that functions are _synchronous_ 
-and behaviours are _asynchronous_. In other words, when you call a function, 
-the body of the function is executed immediately, and the result of the call 
-is the result of the body of the function. This is just like method invocation 
-in any other object-oriented language.
+A __behaviour__ is like a __function__, except that functions are _synchronous_ and behaviours are _asynchronous_. In other words, when you call a function, the body of the function is executed immediately, and the result of the call is the result of the body of the function. This is just like method invocation in any other object-oriented language.
 
-But when you call a behaviour, the body is __not__ executed immediately. 
-Instead, the body of the behaviour will execute at some indeterminate time in 
-the future.
+But when you call a behaviour, the body is __not__ executed immediately. Instead, the body of the behaviour will execute at some indeterminate time in the future.
 
-A behaviour looks like a function, but instead of being introduced with the 
-keyword `fun`, it is introduced with the keyword `be`.
+A behaviour looks like a function, but instead of being introduced with the keyword `fun`, it is introduced with the keyword `be`.
 
-Like a function, a behaviour can have parameters. Unlike a function, it doesn't 
-have a receiver capability (a behaviour can be called on a receiver of any 
-capability) and you can't specify a return type.
+Like a function, a behaviour can have parameters. Unlike a function, it doesn't have a receiver capability (a behaviour can be called on a receiver of any capability) and you can't specify a return type.
 
-__So what does a behaviour return?__ All behaviours always return the receiver. 
-They can't return something they calculate (since they haven't run yet), so 
-returning the receiver is a convenience to allow chaining calls on the receiver.
+__So what does a behaviour return?__ All behaviours always return the receiver. They can't return something they calculate (since they haven't run yet), so returning the receiver is a convenience to allow chaining calls on the receiver.
 
 ```pony
 actor Aardvark
@@ -42,51 +30,28 @@ Here we have an `Aardvark` that can eat asynchronously. Clever Aardvark.
 
 ## Concurrent
 
-Since behaviours are asynchronous, it's ok to run the body of a bunch of 
-behaviours at the same time. This is exactly what Pony does. The Pony runtime 
-has its own scheduler, which by default has a number of threads equal to the 
-number of CPU cores on your machine. Each scheduler thread can be executing an 
-actor behaviour at any given time, so Pony programs are naturally concurrent.
+Since behaviours are asynchronous, it's ok to run the body of a bunch of behaviours at the same time. This is exactly what Pony does. The Pony runtime has its own scheduler, which by default has a number of threads equal to the number of CPU cores on your machine. Each scheduler thread can be executing an actor behaviour at any given time, so Pony programs are naturally concurrent.
 
 ## Sequential
 
-Actors themselves, however, are sequential. That is, each actor will only 
-execute one behaviour at a time. This means all the code in an actor can be 
-written without caring about concurrency: no need for locks or semaphores or 
-anything like that.
+Actors themselves, however, are sequential. That is, each actor will only execute one behaviour at a time. This means all the code in an actor can be written without caring about concurrency: no need for locks or semaphores or anything like that.
 
-When you're writing Pony code, it's nice to think of actors not as a unit of 
-parallelism, but as a unit of sequentiality. That is, an actor should do only 
-what _has_ to be done sequentially. Anything else can be broken out into 
-another actor, making it automatically parallel.
+When you're writing Pony code, it's nice to think of actors not as a unit of parallelism, but as a unit of sequentiality. That is, an actor should do only what _has_ to be done sequentially. Anything else can be broken out into another actor, making it automatically parallel.
 
 ## Why is this safe?
 
-Because of Pony's __capabilities secure type system__. We've mentioned 
-reference capabilities briefly before, when talking about function receiver 
-reference capabilities. The short version is that they are annotations on a 
-type that make all this parallelism safe without any runtime overhead.
+Because of Pony's __capabilities secure type system__. We've mentioned reference capabilities briefly before, when talking about function receiver reference capabilities. The short version is that they are annotations on a type that make all this parallelism safe without any runtime overhead.
 
 We will cover reference capabilities in depth later.
 
 ## Actors are cheap
 
-If you've done concurrent programming before, you'll know that threads can be 
-expensive. Context switches can cause problems, each thread needs a stack 
-(which can be a lot of memory), and you need lots of locks and other mechanisms 
-to write thread-safe code.
+If you've done concurrent programming before, you'll know that threads can be expensive. Context switches can cause problems, each thread needs a stack (which can be a lot of memory), and you need lots of locks and other mechanisms to write thread-safe code.
 
-But actors are cheap. Really cheap. The extra cost of an actor as opposed to an 
-object is about 256 bytes of memory. Bytes, not kilobytes! And there are no 
-locks and no context switches. An actor that isn't executing consumes no 
-resources other than the few extra bytes of memory.
+But actors are cheap. Really cheap. The extra cost of an actor as opposed to an object is about 256 bytes of memory. Bytes, not kilobytes! And there are no locks and no context switches. An actor that isn't executing consumes no resources other than the few extra bytes of memory.
 
-It's pretty normal to write a Pony program that uses hundreds of thousands of 
-actors.
+It's pretty normal to write a Pony program that uses hundreds of thousands of actors.
 
 ## Actor finalisers
 
-Like classes, actors can have finalisers. The finaliser definition is the same
-(`fun _final()`). All guarantees and restrictions for a class finaliser are
-also valid for an actor finaliser. In addition, an actor will not receive any
-further message after its finaliser is called.
+Like classes, actors can have finalisers. The finaliser definition is the same (`fun _final()`). All guarantees and restrictions for a class finaliser are also valid for an actor finaliser. In addition, an actor will not receive any further message after its finaliser is called.

--- a/types/at-a-glance.md
+++ b/types/at-a-glance.md
@@ -1,64 +1,38 @@
 # The Pony Type System at a Glance
 
-Pony is a _statically typed_ language, like Java, C#, C++, and many others. 
-This means the compiler knows the type of everything in your program. This is 
-different from _dynamically typed_ languages, such as Python, Lua, JavaScript, 
-and Ruby.
+Pony is a _statically typed_ language, like Java, C#, C++, and many others. This means the compiler knows the type of everything in your program. This is different from _dynamically typed_ languages, such as Python, Lua, JavaScript, and Ruby.
 
 ## Static vs Dynamic: What's the difference?
 
 In both kinds of language, your data has a type. So what's the difference?
 
-With a _dynamically typed_ language, a variable can point to objects of 
-different types at different times. This is flexible, because if you have a 
-variable `x`, you can assign an integer to it, then assign a string to it, and 
-your compiler or interpreter doesn't complain.
+With a _dynamically typed_ language, a variable can point to objects of different types at different times. This is flexible, because if you have a variable `x`, you can assign an integer to it, then assign a string to it, and your compiler or interpreter doesn't complain.
 
-__But what if I try to do a string operation on `x` after assigning an integer 
-to it?__ Generally speaking, your program will raise an error. You might be 
-able to handle the error in some way, depending on the language, but if you 
-don't, your program will crash.
+__But what if I try to do a string operation on `x` after assigning an integer to it?__ Generally speaking, your program will raise an error. You might be able to handle the error in some way, depending on the language, but if you don't, your program will crash.
 
-When you use a _statically typed_ language, a variable has a type. That is, it 
-can only point to objects of a certain type (although in Pony, a type can 
-actually be a collection of types, as we'll see later). If you have an `x` 
-that expects to point to an integer, you can't assign a string to it. Your 
-compiler complains, and it complains __before__ you ever try to run your 
-program.
+When you use a _statically typed_ language, a variable has a type. That is, it can only point to objects of a certain type (although in Pony, a type can actually be a collection of types, as we'll see later). If you have an `x` that expects to point to an integer, you can't assign a string to it. Your compiler complains, and it complains __before__ you ever try to run your program.
 
 ## Types are guarantees
 
-When the compiler knows what types things are, it can make sure some things in 
-your program work without you having to run it or test it. These things are 
-the _guarantees_ that a language's type system provides.
+When the compiler knows what types things are, it can make sure some things in your program work without you having to run it or test it. These things are the _guarantees_ that a language's type system provides.
 
-The more powerful a type system is, the more things it can prove about your 
-program without having to run it.
+The more powerful a type system is, the more things it can prove about your program without having to run it.
 
-__Do dynamic types make guarantees too?__ Yes, but they do it at runtime. For 
-example, if you call a method that doesn't exist, you will usually get some 
-kind of exception. But you'll only find out when you try to run your program.
+__Do dynamic types make guarantees too?__ Yes, but they do it at runtime. For example, if you call a method that doesn't exist, you will usually get some kind of exception. But you'll only find out when you try to run your program.
 
 ## What guarantees does Pony's type system give me?
 
-The Pony type system offers a lot of guarantees, even more than other 
-statically typed languages.
+The Pony type system offers a lot of guarantees, even more than other statically typed languages.
 
 * If your program compiles, it won't crash.
 * There will never be an unhandled exception.
-* There's no such thing as `null`, so your program will never try to 
-dereference `null`.
+* There's no such thing as `null`, so your program will never try to dereference `null`.
 * There will never be a data race.
 * Your program will never deadlock.
 * Your code will always be capabilities-secure.
-* All message passing is 
+* All message passing is
 [causal](https://www.google.com/search?q=causal+definition). (Not ca**su**al!)
 
-Some of those will make sense right now. Some of them may not mean much to you 
-yet (like capabilities-security and causal messaging), but we'll get to those 
-concepts later on.
+Some of those will make sense right now. Some of them may not mean much to you yet (like capabilities-security and causal messaging), but we'll get to those concepts later on.
 
-__If I use Pony's FFI to call code written in another language, does Pony 
-magically make the same guarantees for the code I call?__ Sadly, no. Pony's 
-type system guarantees only apply to code written in Pony. Code written in 
-other languages gets only the guarantees provided by that language.
+__If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony's type system guarantees only apply to code written in Pony. Code written in other languages gets only the guarantees provided by that language.

--- a/types/classes.md
+++ b/types/classes.md
@@ -1,16 +1,12 @@
 # Classes
 
-Just like other object-oriented languages, Pony has __classes__. A class is 
-declared with the keyword `class`, and it has to have a name that starts with a 
-capital letter, like this:
+Just like other object-oriented languages, Pony has __classes__. A class is declared with the keyword `class`, and it has to have a name that starts with a capital letter, like this:
 
 ```pony
 class Wombat
 ```
 
-__Do all types start with a capital letter?__ Yes! And nothing else starts with 
-a capital letter. So when you see a name in Pony code, you will instantly know 
-whether it's a type or not.
+__Do all types start with a capital letter?__ Yes! And nothing else starts with a capital letter. So when you see a name in Pony code, you will instantly know whether it's a type or not.
 
 ## What goes in a class?
 
@@ -22,10 +18,7 @@ A class is composed of:
 
 ### Fields
 
-These are just like fields in C structs or fields in classes in C++, C#, Java, 
-Python, Ruby, or basically any language, really. There are two kinds of fields: 
-var fields and let fields. A var field can be assigned to over and over again, 
-but a let field is assigned to in the constructor and never again.
+These are just like fields in C structs or fields in classes in C++, C#, Java, Python, Ruby, or basically any language, really. There are two kinds of fields: var fields and let fields. A var field can be assigned to over and over again, but a let field is assigned to in the constructor and never again.
 
 ```pony
 class Wombat
@@ -33,20 +26,13 @@ class Wombat
   var _hunger_level: U64
 ```
 
-Here, a `Wombat` has a `name`, which is a `String`, and a `_hunger_level`, 
-which is a `U64` (an unsigned 64 bit integer).
+Here, a `Wombat` has a `name`, which is a `String`, and a `_hunger_level`, which is a `U64` (an unsigned 64 bit integer).
 
-__What does the leading underscore mean?__ It means something is __private__. 
-A __private__ field can only be accessed by code in the same type. A 
-__private__ constructor, function, or behaviour can only be accessed by code in 
-the same package. We'll talk more about packages later.
+__What does the leading underscore mean?__ It means something is __private__. A __private__ field can only be accessed by code in the same type. A __private__ constructor, function, or behaviour can only be accessed by code in the same package. We'll talk more about packages later.
 
 ### Constructors
 
-Pony constructors have names. Other than that, they are just like constructors 
-in other languages. They can have parameters, and they always return a new 
-instance of the type. Since they have names, you can have more than one 
-constructor for a type.
+Pony constructors have names. Other than that, they are just like constructors in other languages. They can have parameters, and they always return a new instance of the type. Since they have names, you can have more than one constructor for a type.
 
 Constructors are introduced with the __new__ keyword.
 
@@ -64,19 +50,11 @@ class Wombat
     _hunger_level = hunger'
 ```
 
-Here, we have two constructors, one that creates a `Wombat` that isn't hungry, 
-and another that creates a `Wombat` that might be hungry or might not.
+Here, we have two constructors, one that creates a `Wombat` that isn't hungry, and another that creates a `Wombat` that might be hungry or might not.
 
-__What's with the single quote thing, i.e. name'?__ You can use single quotes 
-in parameter and local variable names. In mathematics, it's called a _prime_, 
-and it's used to say "another one of these, but not the same one". Basically, 
-it's just convenient.
+__What's with the single quote thing, i.e. name'?__ You can use single quotes in parameter and local variable names. In mathematics, it's called a _prime_, and it's used to say "another one of these, but not the same one". Basically, it's just convenient.
 
-Every constructor has to set every field in an object. If it doesn't, the 
-compiler will give you an error. Since there is no `null` in Pony, we can't do 
-what Java, C# and many other languages do and just assign either `null` or zero 
-to every field before the constructor runs, and since we don't want random 
-crashes, we don't leave fields undefined (unlike C or C++).
+Every constructor has to set every field in an object. If it doesn't, the compiler will give you an error. Since there is no `null` in Pony, we can't do what Java, C# and many other languages do and just assign either `null` or zero to every field before the constructor runs, and since we don't want random crashes, we don't leave fields undefined (unlike C or C++).
 
 Sometimes it's convenient to set a field the same way for all constructors.
 
@@ -95,15 +73,11 @@ class Wombat
     _hunger_level = hunger'
 ```
 
-Here, every `Wombat` begins a little bit thirsty, regardless of which 
-constructor is called.
+Here, every `Wombat` begins a little bit thirsty, regardless of which constructor is called.
 
 ### Functions
 
-Functions in Pony are like methods in Java, C#, C++, Ruby, Python, or pretty 
-much any other object oriented language. They are introduced with the keyword 
-`fun`. They can have parameters, like constructors do, and they can also have a 
-result type (if no result type is given, it defaults to `None`).
+Functions in Pony are like methods in Java, C#, C++, Ruby, Python, or pretty much any other object oriented language. They are introduced with the keyword `fun`. They can have parameters, like constructors do, and they can also have a result type (if no result type is given, it defaults to `None`).
 
 ```pony
 class Wombat
@@ -124,56 +98,31 @@ class Wombat
   fun ref set_hunger(to: U64 = 0): U64 => _hunger_level = to
 ```
 
-The first function, `hunger`, is pretty straight forward. It has a result type 
-of `U64`, and it returns `_hunger_level`, which is a `U64`. The only thing a 
-bit different here is that no `return` keyword is used. This is because the 
-result of a function is the result of the last expression in the function, in 
-this case the value of `_hunger_level`.
+The first function, `hunger`, is pretty straight forward. It has a result type of `U64`, and it returns `_hunger_level`, which is a `U64`. The only thing a bit different here is that no `return` keyword is used. This is because the result of a function is the result of the last expression in the function, in this case the value of `_hunger_level`.
 
-__Is there a `return` keyword in Pony?__ Yes. It's used to return "early" from 
-a function, i.e. to return something right away and not keep running until the 
-last expression.
+__Is there a `return` keyword in Pony?__ Yes. It's used to return "early" from a function, i.e. to return something right away and not keep running until the last expression.
 
-The second function, `set_hunger`, introduces a _bunch_ of new concepts all at 
-once. Let's go through them one by one.
+The second function, `set_hunger`, introduces a _bunch_ of new concepts all at once. Let's go through them one by one.
 
 * The `ref` keyword right after `fun`
 
-This is a __reference capability__. In this case, it means the _receiver_, i.e. 
-the object on which the `set_hunger` function is being called, has to be a 
-`ref` type. A `ref` type is a __reference type__, meaning that the object is 
-__mutable__. We need this because we are writing a new value to the 
-`_hunger_level` field.
+This is a __reference capability__. In this case, it means the _receiver_, i.e. the object on which the `set_hunger` function is being called, has to be a `ref` type. A `ref` type is a __reference type__, meaning that the object is __mutable__. We need this because we are writing a new value to the `_hunger_level` field.
 
-__What's the receiver reference capability of the `hunger` method?__ The 
-default receiver reference capability if none is specified is `box`, which 
-means "I need to be able to read from this, but I won't write to it".
+__What's the receiver reference capability of the `hunger` method?__ The default receiver reference capability if none is specified is `box`, which means "I need to be able to read from this, but I won't write to it".
 
-__What would happen if we left the `ref` keyword off the `set_hunger` method?__ 
-The compiler would give you an error. It would see you were trying to modify a 
-field and complain about it.
+__What would happen if we left the `ref` keyword off the `set_hunger` method?__ The compiler would give you an error. It would see you were trying to modify a field and complain about it.
 
 * The `= 0` after the parameter `to`
 
-This is a __default argument__. It means that if you don't include that 
-argument at the call site, you will get the default argument. In this case, 
-`to` will be zero if you don't specify it.
+This is a __default argument__. It means that if you don't include that argument at the call site, you will get the default argument. In this case, `to` will be zero if you don't specify it.
 
 * What does the function return?
 
 It returns the _old_ value of `_hunger_level`.
 
-__Wait, seriously? The _old_ value?__ Yes. In Pony, assignment is an expression 
-rather than a statement. That means it has a result. This is true of a lot of 
-languages, but they tend to return the _new_ value. In other words, given 
-`a = b`, in most languages, the value of that is the value of `b`. But in Pony, 
-the value of that is the _old_ value of `a`.
+__Wait, seriously? The _old_ value?__ Yes. In Pony, assignment is an expression rather than a statement. That means it has a result. This is true of a lot of languages, but they tend to return the _new_ value. In other words, given `a = b`, in most languages, the value of that is the value of `b`. But in Pony, the value of that is the _old_ value of `a`.
 
-__...why?__ It's called a "destructive read", and it lets you do awesome things 
-with a capabilities-secure type system. We'll talk about that more later. For 
-now, we'll just mention that you can also use it to implement a _swap_ 
-operation. In most languages, to swap the values of `a` and `b` you need to do 
-something like:
+__...why?__ It's called a "destructive read", and it lets you do awesome things with a capabilities-secure type system. We'll talk about that more later. For now, we'll just mention that you can also use it to implement a _swap_ operation. In most languages, to swap the values of `a` and `b` you need to do something like:
 
 ```pony
 var temp = a
@@ -189,44 +138,24 @@ a = b = a
 
 ### Finalisers
 
-Finalisers are special functions. They are named `_final`, take no parameters
-and have a receiver reference capability of `box`. In other words, the
-definition of a finaliser must be `fun _final()`.
+Finalisers are special functions. They are named `_final`, take no parameters and have a receiver reference capability of `box`. In other words, the definition of a finaliser must be `fun _final()`.
 
-The finaliser of an object is called before the object is collected by the GC.
-Functions may still be called on an object after its finalisation, but only
-from within another finaliser. Messages cannot be sent from within a finaliser.
+The finaliser of an object is called before the object is collected by the GC. Functions may still be called on an object after its finalisation, but only from within another finaliser. Messages cannot be sent from within a finaliser.
 
-Finalisers are usually used to clean up resources allocated in C code, like
-file handles, network sockets, etc.
+Finalisers are usually used to clean up resources allocated in C code, like file handles, network sockets, etc.
 
 ## What about inheritance?
 
-In some object-oriented languages, a type can _inherit_ from another type, like 
-how in Java something can __extend__ something else. Pony doesn't do that. 
-Instead, Pony prefers _composition_ to _inheritance_. In other words, instead 
-of getting code reuse by saying something __is__ something else, you get it by 
-saying something __has__ something else.
+In some object-oriented languages, a type can _inherit_ from another type, like how in Java something can __extend__ something else. Pony doesn't do that. Instead, Pony prefers _composition_ to _inheritance_. In other words, instead of getting code reuse by saying something __is__ something else, you get it by saying something __has__ something else.
 
-On the other hand, Pony has a powerful __trait__ system (similar to Java 8 
-interfaces that can have default implementations) and a powerful __interface__ 
-system (similar to Go interfaces, i.e. structurally typed).
+On the other hand, Pony has a powerful __trait__ system (similar to Java 8 interfaces that can have default implementations) and a powerful __interface__ system (similar to Go interfaces, i.e. structurally typed).
 
 We'll talk about all that stuff in detail later.
 
 ## Naming rules
 
-By now it shouldn't be very surprising to learn that Pony is written in 
-__ASCII__. [ASCII](https://en.wikipedia.org/wiki/ASCII) is a standard text 
-encoding that uses English characters and symbols, and almost every programming 
-language in existence defines source code as a subset of it.
+By now it shouldn't be very surprising to learn that Pony is written in __ASCII__. [ASCII](https://en.wikipedia.org/wiki/ASCII) is a standard text encoding that uses English characters and symbols, and almost every programming language in existence defines source code as a subset of it.
 
-A Pony type, whether it's a class, actor, trait, interface, primitive, 
-or type alias, must start with an uppercase letter. After an underscore for 
-private or special _methods_ (behaviors, constructors, and functions), any 
-method or variable, including parameters and fields, must start with a 
-lowercase letter. In all cases underscores in a row or at the end of a name are 
-not allowed, but otherwise any combination of letters and numbers is legal.
+A Pony type, whether it's a class, actor, trait, interface, primitive, or type alias, must start with an uppercase letter. After an underscore for private or special _methods_ (behaviors, constructors, and functions), any method or variable, including parameters and fields, must start with a lowercase letter. In all cases underscores in a row or at the end of a name are not allowed, but otherwise any combination of letters and numbers is legal.
 
-In fact, numbers may use single underscores inside as a separator too! But only 
-valid variable names can end in primes.
+In fact, numbers may use single underscores inside as a separator too! But only valid variable names can end in primes.

--- a/types/index.md
+++ b/types/index.md
@@ -1,10 +1,5 @@
 # Chapter 2: Types
 
-Pony's type system is what makes it special. There's plenty to love about it
-otherwise but, in the end, it's the type system that contains much of what makes
-Pony novel. In this chapter we are going to explore the basics of the type
-system. If you worked with a statically typed language before, there shouldn't
-be anything surprising to you. By the time you've finished this chapter, you
-should have a handle on basics of the Pony type system.
+Pony's type system is what makes it special. There's plenty to love about it otherwise but, in the end, it's the type system that contains much of what makes Pony novel. In this chapter we are going to explore the basics of the type system. If you worked with a statically typed language before, there shouldn't be anything surprising to you. By the time you've finished this chapter, you should have a handle on basics of the Pony type system.
 
 

--- a/types/primitives.md
+++ b/types/primitives.md
@@ -1,60 +1,35 @@
 # Primitives
 
-A __primitive__ is similar to a __class__, but there are two critical 
-differences:
+A __primitive__ is similar to a __class__, but there are two critical differences:
 
 1. A __primitive__ has no fields.
 2. There is only one instance of a user-defined __primitive__.
 
-Having no fields means primitives are never mutable. Having a single instance 
-means that if your code calls a constructor on a __primitive__ type, it always 
-gets the same result back (except for built-in "machine word" primitives, 
-covered below).
+Having no fields means primitives are never mutable. Having a single instance means that if your code calls a constructor on a __primitive__ type, it always gets the same result back (except for built-in "machine word" primitives, covered below).
 
 ## What can you use a __primitive__ for?
 
-There are three main uses of primitives (four, if you count built-in 
-"machine word" primitives).
+There are three main uses of primitives (four, if you count built-in "machine word" primitives).
 
-1. As a "marker value". For example, Pony often uses the __primitive__ `None` 
-to indicate that something has "no value". Of course, it _does_ have a value, 
-so that you can check what it is, and the value is the single instance of 
-`None`.
-2. As an "enumeration" type. By having a __union__ of __primitive__ types, 
-you can have a type-safe enumeration. We'll cover __union__ types later.
-3. As a "collection of functions". Since primitives can have functions, you can 
-group functions together in a primitive type. You can see this in the standard 
-library, where path handling functions are grouped in the __primitive__ `Path`, 
-for example.
+1. As a "marker value". For example, Pony often uses the __primitive__ `None` to indicate that something has "no value". Of course, it _does_ have a value, so that you can check what it is, and the value is the single instance of `None`.
+2. As an "enumeration" type. By having a __union__ of __primitive__ types, you can have a type-safe enumeration. We'll cover __union__ types later.
+3. As a "collection of functions". Since primitives can have functions, you can group functions together in a primitive type. You can see this in the standard library, where path handling functions are grouped in the __primitive__ `Path`, for example.
 
-Primitives are quite powerful, particularly as enumerations. Unlike 
-enumerations in other languages, each "value" in the enumeration is a complete 
-type, which makes attaching data and functionality to enumeration values easy.
+Primitives are quite powerful, particularly as enumerations. Unlike enumerations in other languages, each "value" in the enumeration is a complete type, which makes attaching data and functionality to enumeration values easy.
 
 ## Built-in primitive types
 
-The __primitive__ keyword is also used to introduce certain built-in 
-"machine word" types. Other than having a value associated with them, these 
-work like user-defined primitives. These are:
+The __primitive__ keyword is also used to introduce certain built-in "machine word" types. Other than having a value associated with them, these work like user-defined primitives. These are:
 
 * __Bool__. This is a 1-bit value that is either `true` or `false`.
 * __ISize, ILong, I8, I16, I32, I64, I128__. Signed integers of various widths.
-* __USize, ULong, U8, U16, U32, U64, U128__. Unsigned integers of various 
-widths.
+* __USize, ULong, U8, U16, U32, U64, U128__. Unsigned integers of various widths.
 * __F32, F64__. Floating point numbers of various widths.
 
-__ISize/USize__ correspond to the bitwidth of the native type `size_t`, which 
-varies by platform. __ILong/ULong__ similarly correspond to the bitwidth of the 
-native type `long`, which also varies by platform. The bitwidth of a native `int` 
-is the same across all the platforms that Pony supports, and you can use 
-__I32/U32__ for this.
+__ISize/USize__ correspond to the bitwidth of the native type `size_t`, which varies by platform. __ILong/ULong__ similarly correspond to the bitwidth of the native type `long`, which also varies by platform. The bitwidth of a native `int` is the same across all the platforms that Pony supports, and you can use __I32/U32__ for this.
 
 ## Primitive initialisation and finalisation
 
-Primitives can have two special functions, `_init` and `_final`. `_init` is
-called before any actor starts. `_final` is called after all actors have
-terminated. The two functions take no parameter. The `_init` and `_final`
-functions for different primitives always run sequentially.
+Primitives can have two special functions, `_init` and `_final`. `_init` is called before any actor starts. `_final` is called after all actors have terminated. The two functions take no parameter. The `_init` and `_final` functions for different primitives always run sequentially.
 
-A common use case for this is initialising and cleaning up C libraries without
-risking untimely use by an actor.
+A common use case for this is initialising and cleaning up C libraries without risking untimely use by an actor.

--- a/types/traits-and-interfaces.md
+++ b/types/traits-and-interfaces.md
@@ -1,30 +1,20 @@
 # Traits and Interfaces
 
-Like other object-oriented languages, Pony has __subtyping__. That is, some 
-types serve as _categories_ that other types can be members of.
+Like other object-oriented languages, Pony has __subtyping__. That is, some types serve as _categories_ that other types can be members of.
 
-There are two kinds of __subtyping__ in programming languages: __nominal__ and 
-__structural__. They're subtly different, and most programming languages only 
-have one or the other. Pony has both!
+There are two kinds of __subtyping__ in programming languages: __nominal__ and __structural__. They're subtly different, and most programming languages only have one or the other. Pony has both!
 
 ## Nominal subtyping
 
 This kind of subtyping is called __nominal__ because it is all about __names__.
 
-If you've done object-oriented programming before, you may have seen a lot of 
-discussion about _single inheritance_, _multiple inheritance_, _mixins_, 
-_traits_, and similar concepts. These are all examples of __nominal subtyping__.
+If you've done object-oriented programming before, you may have seen a lot of discussion about _single inheritance_, _multiple inheritance_, _mixins_, _traits_, and similar concepts. These are all examples of __nominal subtyping__.
 
-The core idea is that you have a type that declares it has a relationship to 
-some category type. In Java, for example, a __class__ (a concrete type) can 
-__implement__ an __interface__ (a category type). In Java, this means the class 
-is now in the category that the interface represents. The compiler will check 
-that the class actually provides everything it needs to.
+The core idea is that you have a type that declares it has a relationship to some category type. In Java, for example, a __class__ (a concrete type) can __implement__ an __interface__ (a category type). In Java, this means the class is now in the category that the interface represents. The compiler will check that the class actually provides everything it needs to.
 
 ## Traits: nominal subtyping
 
-Pony has nominal subtyping, using __traits__. A __trait__ looks a bit like a 
-__class__, but it uses the keyword `trait` and it can't have any fields.
+Pony has nominal subtyping, using __traits__. A __trait__ looks a bit like a __class__, but it uses the keyword `trait` and it can't have any fields.
 
 ```pony
 trait Named
@@ -33,58 +23,40 @@ trait Named
 class Bob is Named
 ```
 
-Here, we have a trait `Named` that has a single function `name` that returns a 
-String. It also provides a default implementation of `name` that returns the 
-string literal "Bob".
+Here, we have a trait `Named` that has a single function `name` that returns a String. It also provides a default implementation of `name` that returns the string literal "Bob".
 
-We also have a class `Bob` that says it `is Named`. This means `Bob` is in the 
-`Named` category. In Pony, we say _Bob provides Named_, or sometimes simply 
-_Bob is Named_.
+We also have a class `Bob` that says it `is Named`. This means `Bob` is in the `Named` category. In Pony, we say _Bob provides Named_, or sometimes simply _Bob is Named_.
 
-Since `Bob` doesn't have its own `name` function, it uses the one from the 
-trait. If the trait's function didn't have a default implementation, the 
-compiler would complain that `Bob` had no implementation of `name`.
+Since `Bob` doesn't have its own `name` function, it uses the one from the trait. If the trait's function didn't have a default implementation, the compiler would complain that `Bob` had no implementation of `name`.
 
 ```pony
 class Larry
   fun name(): String => "Larry"
 ```
 
-Here, we have a class `Larry` that has a `name` function with the same 
-signature. But `Larry` does __not__ provide `Named`!
+Here, we have a class `Larry` that has a `name` function with the same signature. But `Larry` does __not__ provide `Named`!
 
-__Wait, why not?__ Because `Larry` doesn't say it `is Named`. Remember, traits 
-are __nominal__: a type that wants to provide a trait has to explicitly declare 
-that it does. And `Larry` doesn't.
+__Wait, why not?__ Because `Larry` doesn't say it `is Named`. Remember, traits are __nominal__: a type that wants to provide a trait has to explicitly declare that it does. And `Larry` doesn't.
 
 ## Structural subtyping
 
-There's another kind of subtyping, where the name doesn't matter. It's called 
-__structural subtyping__, which means that it's all about how a type is built, 
-and nothing to do with names.
+There's another kind of subtyping, where the name doesn't matter. It's called __structural subtyping__, which means that it's all about how a type is built, and nothing to do with names.
 
-A concrete type is a member of a structural category if it happens to have all 
-the needed elements, no matter what it happens to be called.
+A concrete type is a member of a structural category if it happens to have all the needed elements, no matter what it happens to be called.
 
 If you've used Go, you'll recognise that Go interfaces are structural types.
 
 ## Interfaces: stuctural subtyping
 
-Pony has structural subtyping too, using __interfaces__. Interfaces look like 
-traits, but they use the keyword `interface`.
+Pony has structural subtyping too, using __interfaces__. Interfaces look like traits, but they use the keyword `interface`.
 
 ```pony
 interface HasName
   fun name(): String
 ```
 
-Here, `HasName` looks a lot like `Named`, except it's an interface instead of a 
-trait. This means both `Bob` and `Larry` provide `HasName`! The programmers 
-that wrote `Bob` and `Larry` don't even have to be aware that `HasName` exists.
+Here, `HasName` looks a lot like `Named`, except it's an interface instead of a trait. This means both `Bob` and `Larry` provide `HasName`! The programmers that wrote `Bob` and `Larry` don't even have to be aware that `HasName` exists.
 
-Pony interfaces can have functions with default implementations as well. A type 
-will only pick those up if it explicitly declares that it `is` that interface.
+Pony interfaces can have functions with default implementations as well. A type will only pick those up if it explicitly declares that it `is` that interface.
 
-__Should I use traits or interfaces in my own code?__ Both! Interfaces are more 
-flexible, so if you're not sure what you want, use an interface. But traits are 
-a powerful tool as well: they stop _accidental subtyping_.
+__Should I use traits or interfaces in my own code?__ Both! Interfaces are more flexible, so if you're not sure what you want, use an interface. But traits are a powerful tool as well: they stop _accidental subtyping_.

--- a/types/type-aliases.md
+++ b/types/type-aliases.md
@@ -1,18 +1,12 @@
 # Type Aliases
 
-A __type alias__ is just a way to give a different name to a type. This may 
-sound a bit silly: after all, types already have names! However, Pony can 
-express some complicated types, and it can be convenient to have a short way to 
-talk about them.
+A __type alias__ is just a way to give a different name to a type. This may sound a bit silly: after all, types already have names! However, Pony can express some complicated types, and it can be convenient to have a short way to talk about them.
 
-We'll give a couple examples of using type aliases, just to get the feel of 
-them.
+We'll give a couple examples of using type aliases, just to get the feel of them.
 
 ## Enumerations
 
-One way to use type aliases is to express an enumeration. For example, imagine 
-we want to say something must either be Red, Blue or Green. We could write 
-something like this:
+One way to use type aliases is to express an enumeration. For example, imagine we want to say something must either be Red, Blue or Green. We could write something like this:
 
 ```pony
 primitive Red
@@ -22,18 +16,11 @@ primitive Green
 type Colour is (Red | Blue | Green)
 ```
 
-There are two new concepts in there. The first is the type alias, introduced 
-with the keyword `type`. It just means that the name that comes after `type` 
-will be translated by the compiler to the type that comes after `is`.
+There are two new concepts in there. The first is the type alias, introduced with the keyword `type`. It just means that the name that comes after `type` will be translated by the compiler to the type that comes after `is`.
 
-The second new concept is the type that comes after `is`. It's not a single 
-type! Instead, it's a __union__ type. You can read the `|` symbol as __or__ in 
-this context, so the type is "Red or Blue or Green".
+The second new concept is the type that comes after `is`. It's not a single type! Instead, it's a __union__ type. You can read the `|` symbol as __or__ in this context, so the type is "Red or Blue or Green".
 
-A union type is a form of _closed world_ type. That is, it says every type that 
-can possibly be a member of it. In contrast, object-oriented subtyping is 
-usually _open world_, e.g. in Java, an interface can be implemented by any 
-number of classes.
+A union type is a form of _closed world_ type. That is, it says every type that can possibly be a member of it. In contrast, object-oriented subtyping is usually _open world_, e.g. in Java, an interface can be implemented by any number of classes.
 
 You can also declare constants like in C or Go like this,
 ```pony
@@ -51,8 +38,7 @@ primitive Colours
   fun green(): U32 => 0x00FF00FF
 ```
 
-You might also want to iterate over the enum like this to print its name for 
-debugging purposes
+You might also want to iterate over the enum like this to print its name for debugging purposes
 ```pony
 primitive ColourList
   fun tag apply(): Array[Colour] =>
@@ -64,9 +50,7 @@ end
 
 ## Complex types
 
-If a type is complicated, it can be nice to give it a mnemonic name. For 
-example, if we want to say that a type must implement more than one interface, 
-we could say:
+If a type is complicated, it can be nice to give it a mnemonic name. For example, if we want to say that a type must implement more than one interface, we could say:
 
 ```pony
 interface HasName
@@ -96,61 +80,40 @@ trait HasAddress
 type Person is (HasName & HasAge & HasAddress)
 ```
 
-There's another new concept here: the type has a `&` in it. This is similar to 
-the `|` of a __union__ type: it means this is an __intersection__ type. That 
-is, it's something that must be _all_ of `HasName`, `HasAge` _and_ `HasAddress`.
+There's another new concept here: the type has a `&` in it. This is similar to the `|` of a __union__ type: it means this is an __intersection__ type. That is, it's something that must be _all_ of `HasName`, `HasAge` _and_ `HasAddress`.
 
-But the use of `type` here is exactly the same as the enumeration example 
-above, it's just providing a name for a type that is otherwise a bit tedious to 
-type out over and over.
+But the use of `type` here is exactly the same as the enumeration example above, it's just providing a name for a type that is otherwise a bit tedious to type out over and over.
 
-Another example, this time from the standard library, is `SetIs`. Here's the 
-actual definition:
+Another example, this time from the standard library, is `SetIs`. Here's the actual definition:
 
 ```pony
 type SetIs[A] is HashSet[A, HashIs[A!]]
 ```
 
-Again there's something new here. After the name `SetIs` comes the name `A` in 
-square brackets. That's because `SetIs` is a __generic type__. That is, you can 
-give a `SetIs` another type as a parameter, to make specific kinds of set. If 
-you've used Java or C#, this will be pretty familiar. If you've used C++, the 
-equivalent concept is templates, but they work quite differently.
+Again there's something new here. After the name `SetIs` comes the name `A` in square brackets. That's because `SetIs` is a __generic type__. That is, you can give a `SetIs` another type as a parameter, to make specific kinds of set. If you've used Java or C#, this will be pretty familiar. If you've used C++, the equivalent concept is templates, but they work quite differently.
 
-And again the use of `type` just provides a more convenient way to refer to the 
-type we're aliasing:
+And again the use of `type` just provides a more convenient way to refer to the type we're aliasing:
 
 ```pony
 HashSet[A, HashIs[A!]]
 ```
 
-That's another __generic type__. It means a `SetIs` is really a kind of 
-`HashSet`. Another concept has snuck in, which is `!` types. This is a type 
-that is the __alias__ of another type. That's tricky stuff that you only need 
-when writing complex generic types, so we'll leave it for later.
+That's another __generic type__. It means a `SetIs` is really a kind of `HashSet`. Another concept has snuck in, which is `!` types. This is a type that is the __alias__ of another type. That's tricky stuff that you only need when writing complex generic types, so we'll leave it for later.
 
-One more example, again from the standard library, is the `Map` type that gets 
-used a lot. It's actually a type alias. Here's the real definition of `Map`:
+One more example, again from the standard library, is the `Map` type that gets used a lot. It's actually a type alias. Here's the real definition of `Map`:
 
 ```pony
 type Map[K: (Hashable box & Comparable[K] box), V] is HashMap[K, V, HashEq[K]]
 ```
 
-Unlike our previous example, the first type parameter, `K`, has a type 
-associated with it. This is a __constraint__, which means when you parameterise 
-a `Map`, the type you pass for `K` must be a subtype of the constraint.
+Unlike our previous example, the first type parameter, `K`, has a type associated with it. This is a __constraint__, which means when you parameterise a `Map`, the type you pass for `K` must be a subtype of the constraint.
 
-Also notice that `box` appears in the type. This is a __reference capability__. 
-It means there is a certain class of operations we need to be able to do on a 
-`K`. We'll cover this in more detail later.
+Also notice that `box` appears in the type. This is a __reference capability__. It means there is a certain class of operations we need to be able to do on a `K`. We'll cover this in more detail later.
 
-Just like our other examples, all this really means is that `Map` is really a 
-kind of `HashMap`.
+Just like our other examples, all this really means is that `Map` is really a kind of `HashMap`.
 
 ## Other stuff
 
-Type aliases get used for a lot of things, but this gives you the general idea. 
-Just remember that a type alias is always a convenience: you could replace 
-every use of the type alias with the full type after the `is`.
+Type aliases get used for a lot of things, but this gives you the general idea. Just remember that a type alias is always a convenience: you could replace every use of the type alias with the full type after the `is`.
 
 In fact, that's exactly what the compiler does.

--- a/types/type-expressions.md
+++ b/types/type-expressions.md
@@ -1,17 +1,12 @@
 # Type Expressions
 
-The types we've talked about so far can also be combined in 
-__type expressions__. If you're used to object-oriented programming, you may 
-not have seen these before, but they are common in functional programming. A 
-__type expression__ is also called an __algebraic data type__.
+The types we've talked about so far can also be combined in __type expressions__. If you're used to object-oriented programming, you may not have seen these before, but they are common in functional programming. A __type expression__ is also called an __algebraic data type__.
 
-There are three kinds of type expression: __tuples__, __unions__, and 
-__intersections__.
+There are three kinds of type expression: __tuples__, __unions__, and __intersections__.
 
 ## Tuples
 
-A __tuple__ is a sequence of types. For example, if we wanted something that 
-was a `String` followed by a `U64`, we would write this:
+A __tuple__ is a sequence of types. For example, if we wanted something that was a `String` followed by a `U64`, we would write this:
 
 ```pony
 var x: (String, U64)
@@ -19,8 +14,7 @@ x = ("hi", 3)
 x = ("bye", 7)
 ```
 
-All type expressions are written in parentheses, and the elements of a tuple 
-are separated by a comma. We can also destructure a tuple using assignment:
+All type expressions are written in parentheses, and the elements of a tuple are separated by a comma. We can also destructure a tuple using assignment:
 
 ```pony
 (var y, var z) = x
@@ -33,67 +27,49 @@ var y = x._1
 var z = x._2
 ```
 
-Note that there's no way to assign to an element of a tuple. Instead, you can 
-just reassign the entire tuple, like this:
+Note that there's no way to assign to an element of a tuple. Instead, you can just reassign the entire tuple, like this:
 
 ```pony
 x = ("wombat", x._2)
 ```
 
-__Why use a tuple instead of a class?__ Tuples are a way to express a 
-collection of values that doesn't have any associated code or expected 
-behaviour. Basically, if you just need a quick collection of things, maybe to 
-return more than one value from a function for example, you can use a tuple.
+__Why use a tuple instead of a class?__ Tuples are a way to express a collection of values that doesn't have any associated code or expected behaviour. Basically, if you just need a quick collection of things, maybe to return more than one value from a function for example, you can use a tuple.
 
 ## Unions
 
-A __union__ type is written like a __tuple__, but it uses a `|` (pronounced 
-"or" when reading the type) instead of a `,` between its elements. Where a 
-tuple represents a collection of values, a union represents a _single_ value 
-that can be any of the specified types.
+A __union__ type is written like a __tuple__, but it uses a `|` (pronounced "or" when reading the type) instead of a `,` between its elements. Where a tuple represents a collection of values, a union represents a _single_ value that can be any of the specified types.
 
-Unions can be used for tons of stuff that require multiple concepts in other 
-languages. For example, optional values, enumerations, marker values, and more.
+Unions can be used for tons of stuff that require multiple concepts in other languages. For example, optional values, enumerations, marker values, and more.
 
 ```pony
 var x: (String | None)
 ```
 
-Here we have an example of using a union to express an optional type, where `x` 
-might be a `String`, but it also might be `None`.
+Here we have an example of using a union to express an optional type, where `x` might be a `String`, but it also might be `None`.
 
 ## Intersections
 
-An __intersection__ uses a `&` (pronounced "and" when reading the type) between 
-its elements. It represents the exact opposite of a union: it is a _single_ 
-value that is _all_ of the specified types, at the same time!
+An __intersection__ uses a `&` (pronounced "and" when reading the type) between its elements. It represents the exact opposite of a union: it is a _single_ value that is _all_ of the specified types, at the same time!
 
-This can be very useful for combining traits or interfaces, for example. Here's 
-something from the standard library:
+This can be very useful for combining traits or interfaces, for example. Here's something from the standard library:
 
 ```pony
 type Map[K: (Hashable box & Comparable[K] box), V] is HashMap[K, V, HashEq[K]]
 ```
 
-That's a fairly complex type alias, but let's look at the constraint of `K`. 
-It's `(Hashable box & Comparable[K] box)`, which means `K` is `Hashable` _and_ 
-it is `Comparable[K]`, at the same time.
+That's a fairly complex type alias, but let's look at the constraint of `K`. It's `(Hashable box & Comparable[K] box)`, which means `K` is `Hashable` _and_ it is `Comparable[K]`, at the same time.
 
 ## Combining type expressions
 
-Type expressions can be combined into more complex types. Here's another 
-example from the standard library:
+Type expressions can be combined into more complex types. Here's another example from the standard library:
 
 ```pony
 var _array: Array[((K, V) | _MapEmpty | _MapDeleted)]
 ```
 
-Here we have an array where each element is either a tuple of `(K, V)` or a 
-`_MapEmpty` or a `_MapDeleted`.
+Here we have an array where each element is either a tuple of `(K, V)` or a `_MapEmpty` or a `_MapDeleted`.
 
-Because every type expression has parentheses around it, they are actually easy 
-to read once you get the hang of it. However, if you use a complex type 
-expression often, it can be nice to provide a type alias for it.
+Because every type expression has parentheses around it, they are actually easy to read once you get the hang of it. However, if you use a complex type expression often, it can be nice to provide a type alias for it.
 
 ```pony
 type Number is (Signed | Unsigned | Float)
@@ -107,5 +83,4 @@ type Float is (F32 | F64)
 
 Those are all type aliases used by the standard library.
 
-__Is `Number` a type alias for a type expression that contains other type 
-aliases?__ Yes! Fun, and convenient.
+__Is `Number` a type alias for a type expression that contains other type aliases?__ Yes! Fun, and convenient.


### PR DESCRIPTION
This PR reformats markdown files to avoid hard wraps in favor of soft wrapping by our text editors and doc renderers.  It also makes this policy clear in `CONTRIBUTING.md`.

See some discussion here: https://github.com/ponylang/pony-for-x/pull/1#issuecomment-217628633