### PR TITLE
Fix description of tuple type expressons to be more accurate.

### DIFF
--- a/types/type-expressions.md
+++ b/types/type-expressions.md
@@ -6,7 +6,7 @@ There are three kinds of type expression: __tuples__, __unions__, and __intersec
 
 ## Tuples
 
-A __tuple__ is a sequence of types. For example, if we wanted something that was a `String` followed by a `U64`, we would write this:
+A __tuple__ type is a sequence of types. For example, if we wanted something that was a `String` followed by a `U64`, we would write this:
 
 ```pony
 var x: (String, U64)


### PR DESCRIPTION
This clears up a bit of confusion that a new user encountered:

http://irclog.whitequark.org/ponylang/2016-06-08#1465348929-1465349760;