### PR TITLE
Reword introduction text for Consume and Destructive Read section

### DIFF
--- a/capabilities/consume-and-destructive-read.md
+++ b/capabilities/consume-and-destructive-read.md
@@ -1,6 +1,6 @@
 # Consume and Destructive Read
 
-And important part of Pony's capabilities are being able to say "I'm done with this thing". In this section, we're going to cover two means of doing that: consuming a variable and destructive reads.
+An important part of Pony's capabilities are being able to say "I'm done with this thing". We'll cover two means of handling this situation: consuming a variable and destructive reads.
 
 ## Consuming a variable
 


### PR DESCRIPTION
This pull requests rewords the intro text in the section describing consume and destructive read to fix a typo ("And" to "An") and to attempt to improve the readability of the sentence.