### PR TITLE
Change print(count) to print(count.string())

### DIFF
--- a/expressions/control-structures.md
+++ b/expressions/control-structures.md
@@ -112,7 +112,7 @@ Here's an example that prints out the numbers 1 to 10:
 var count: U32 = 1
 
 while count <= 10 do
-  env.out.print(count)
+  env.out.print(count.string())
   count = count + 1
 end
 ```


### PR DESCRIPTION
Pony does not allow printing a UI32 without .string()