### PR TITLE
Add clarifications on how to compile using Docker.

### DIFF
--- a/getting-started/hello-world.md
+++ b/getting-started/hello-world.md
@@ -37,6 +37,8 @@ Writing ./helloworld.o
 Linking ./helloworld
 ```
 
+(If you're using Docker, you'd write something like `$ docker run -v Some_Absolute_Path/helloworld:/src/main ponylang/ponyc`, depending of course on what the absolute path to your `helloworld` directory is.)
+
 Look at that! It built the current directory, `.`, plus the stuff that is built in to Pony, `builtin`, it generated some code, optimised it, created an object file (don't worry if you don't know what that is), and linked it into an executable with whatever libraries were needed. If you're a C/C++ programmer, that will all make sense to you, otherwise it probably won't, but that's ok, you can ignore it.
 
 __Wait, it linked too?__ Yes. You won't need a build system (like `make`) for Pony. It handles that for you (including handling the order of dependencies when you link to C libraries, but we'll get to that later).

--- a/getting-started/installation.md
+++ b/getting-started/installation.md
@@ -24,6 +24,8 @@ Then you'll be able to run `ponyc` to compile a Pony program in a given director
 docker run -v /path/to/my-code:/src/main ponylang/ponyc
 ```
 
+If you're unfamiliar with Docker, remember to ensure that whatever path you provide for `/path/to/my-code` is a full path name and not a relative path, and also note the lack of a closing slash, `/`, at the *end* of the path name.
+
 Note that if your host doesn't match the docker container, you'll probably have to run the resulting program inside the docker container as well, using a command like this:
 
 ```bash
@@ -113,10 +115,10 @@ You should install LLVM as supplied by the LLVM build server. If you visit [thei
 Precise (12.04) - Last update : Sun, 22 May 2016 19:26:23 UTC / Revision: 270357
 deb http://llvm.org/apt/precise/ llvm-toolchain-precise main
 deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise main
-# 3.7 
+# 3.7
 deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main
 deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main
-# 3.8 
+# 3.8
 deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main
 deb-src http://llvm.org/apt/precise/ llvm-toolchain-precise-3.8 main
 ```


### PR DESCRIPTION
Building from source is something that a fair amount of people (myself included) will always shy away from unless absolutely necessary. Docker is the next available option for Pony, but not everyone has used Docker. This request proposes two minor additions to the installation and build instructions. These additions are targeted towards people who are unfamiliar with Docker, and preempt at least two sources of potential mishap and confusion. Namely: 

* You must use absolute paths
* The absolute path must not end with a trailing slash, `/`