### PR TITLE
Add notes about overloaded functions

### DIFF
--- a/expressions/infix-ops.md
+++ b/expressions/infix-ops.md
@@ -72,7 +72,7 @@ class Foo
 	var z = x + y
 ```
 
-Since Pony does not allow overloading of functions by argument type, each type can only have a single `add` function. It is possible to overload infix operators to some degree using union types or f-bounded polymorphism, but this is beyond the scope of this tutorial. See the Pony standard library for further information.
+(Case functions)[http://tutorial.ponylang.org/pattern-matching/case-functions.html] can be used to provide more than one `add` function. It is also possible to overload infix operators to some degree using union types or f-bounded polymorphism, but this is beyond the scope of this tutorial. See the Pony standard library for further information.
 
 You do not have to worry about any of this if you don't want to. You can simply use the existing infix operators for numbers just like any other language and not provide them for your own types.
 

--- a/expressions/methods.md
+++ b/expressions/methods.md
@@ -39,7 +39,7 @@ class C
 	x * factorial(x - 1)
 ```
 
-__Can I overload functions by argument type?__ No. There is no overloading of methods in Pony - each type may only have a single method of any given name.
+__Can I overload functions by argument type?__ (Case functions)[http://tutorial.ponylang.org/pattern-matching/case-functions.html] provide a mechanism for providing several functions with the same name with different implementations that are selected by argument type.
 
 ## Constructors
 

--- a/pattern-matching/case-functions.md
+++ b/pattern-matching/case-functions.md
@@ -83,4 +83,33 @@ actor Main
     end
 ```
 
+It is important to note that case functions resolve overlapping cases by using the first function that matches. For example, the prints `foo bar` because the case of `foo` matching the type `Foo` is declared before the one that matches `Bar`, and the case of `bar` matching the type `Bar` is declared before the one that matches `Foo`:
+
+```
+interface Foo
+
+class Bar is Foo
+  new ref create() =>
+    None
+
+actor Main
+  fun foo(x: Foo): String => "foo"
+  fun foo(x: Bar): String => "bar"
+
+  fun bar(x: Bar): String => "bar"
+  fun bar(x: Foo): String => "foo"
+
+  new create(env: Env) =>
+    let x = Bar
+    try
+      env.out.print((foo(x) as String) + " " + (bar(x) as String))
+    end
+```
+
 Case functions can improve readability by making it clear that certain argument will cause certain code paths to execute. They are currently implemented as sugar that translates to a `match` statement, so there is no more overhead than if the programmer had written the `match` themselves.
+
+__Does Pony support overloaded functions?__ There is no strict definition of "overloaded function" so it is difficult to give a definitive answer to this question. Case functions provide a way to supply several functions of the same name with behavior that varies based on the types and values of their arguments; for some people these look like overloaded functions. However, it is important to understand the differences between case functions and some of the traditional expectations of overloaded functions.
+* The current implementation of case functions does not do an exhaustive match to determine the return type of the synthesized function, so the return type is always a union that includes `None` as one of the types.
+* Case functions do not provide a way to specify functions with the same name but different argument counts.
+* Overlapping matches are handled in the order in which the functions were declared.
+Depending on your needs, case functions may or may not offer an acceptable alternative to overloaded functions.


### PR DESCRIPTION
Several places in the tutorial stated that Pony does not support
overloaded functions. While possibly true for some definition of the
term "overloaded function", this caused some confusion because Pony
does support case functions, which achieve several of the goals of
overloaded functions.

This change adds links to the case function documentation in places
case functions might be helpful, and adds a section to the case
function documentation discussing the ways that case functions might
differ from ones expectations of overloaded functions.

Fixes #106