### PR TITLE
Fix markdown link syntax in "Methods" section

### DIFF
--- a/expressions/methods.md
+++ b/expressions/methods.md
@@ -39,7 +39,7 @@ class C
 	x * factorial(x - 1)
 ```
 
-__Can I overload functions by argument type?__ (Case functions)[http://tutorial.ponylang.org/pattern-matching/case-functions.html] provide a mechanism for providing several functions with the same name with different implementations that are selected by argument type.
+__Can I overload functions by argument type?__ [Case functions](http://tutorial.ponylang.org/pattern-matching/case-functions.html) provide a mechanism for providing several functions with the same name with different implementations that are selected by argument type.
 
 ## Constructors
 


### PR DESCRIPTION
`(Title)[url] -> [Title](url)`