### PR TITLE
add proof link

### DIFF
--- a/docs/getting-started/installation.md
+++ b/docs/getting-started/installation.md
@@ -97,7 +97,17 @@ emerge dev-lang/pony
 
 # Windows
 
-64-Bit installers for Windows 7, 8, 8.1 and 10 will be available soon.
+For 64-Bit Windows, the `master` and `release` branches are packaged and availabe Windows only on Bintray ([pony-language/ponyc-win](https://bintray.com/pony-language/ponyc-win)):
+
+```powershell
+Invoke-WebRequest -Uri https://dl.bintray.com/pony-language/ponyc-win/ponyc-VERSION.zip -UseBasicParsing -OutFile ponyc-VERSION.zip
+7z x .\ponyc-VERSION.zip
+.\ponyc-VERSION\ponyc\bin\ponyc.exe --version
+```
+
+You will also need [LLVM for Windows](http://releases.ponylang.org/llvm/).
+
+Windows 10 users will need to install the Windows 10 SDK in order to build programs with ponyc. It can be downloaded [from Microsoft](https://developer.microsoft.com/en-us/windows/downloads/windows-10-sdk).
 
 ## Did it work?
 
@@ -111,6 +121,6 @@ $ ponyc --version
 # Downloads
 All installers can also be downloaded from ponylang.org's servers:
 
-* [Ubuntu/Debian](http://releases.ponylang.org/debian/)
+* [Ubuntu/Debian](http://releases.ponylang.org/apt/)
 * [RPM](http://releases.ponylang.org/yum/)
-* [Windows](http://releases.ponylang.org/windows/)
+* [LLVM for Windows](http://releases.ponylang.org/llvm/)

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,7 +14,7 @@ Pony is an object-oriented, actor-model, capabilities-secure programming languag
 
 When we say Pony is __capabilities-secure__, we mean a few things:
 
-* It's type safe. Really type safe. There's a mathematical proof and everything.
+* It's type safe. Really type safe. There's a mathematical [proof](https://github.com/ponylang/ponylang.github.io/blob/master/media/papers/opsla237-clebsch.pdf) and everything.
 * It's memory safe. Ok, this comes with type safe, but it's still interesting. There are no dangling pointers, no buffer overruns, heck, the language doesn't even have the concept of _null_!
 * It's exception safe. There are no runtime exceptions. All exceptions have defined semantics, and they are _always_ handled.
 * It's data-race free. Pony doesn't have locks or atomic operations or anything like that. Instead, the type system ensures _at compile time_ that your concurrent program can never have data races. So you can write highly concurrent code and never get it wrong.

--- a/docs/index.md
+++ b/docs/index.md
@@ -14,10 +14,12 @@ Pony is an object-oriented, actor-model, capabilities-secure programming languag
 
 When we say Pony is __capabilities-secure__, we mean a few things:
 
-* It's type safe. Really type safe. There's a mathematical [proof](https://github.com/ponylang/ponylang.github.io/blob/master/media/papers/opsla237-clebsch.pdf) and everything.
+* It's type safe. Really type safe. There's a mathematical [proof](https://github.com/ponylang/ponylang.github.io/blob/master/media/papers/opsla237-clebsch.pdf) and everything.<sup>[1](#fn1)</sup>
 * It's memory safe. Ok, this comes with type safe, but it's still interesting. There are no dangling pointers, no buffer overruns, heck, the language doesn't even have the concept of _null_!
 * It's exception safe. There are no runtime exceptions. All exceptions have defined semantics, and they are _always_ handled.
 * It's data-race free. Pony doesn't have locks or atomic operations or anything like that. Instead, the type system ensures _at compile time_ that your concurrent program can never have data races. So you can write highly concurrent code and never get it wrong.
 * It's deadlock free. This one is easy, because Pony has no locks at all! So they definitely don't deadlock, because they don't exist.
 
 We'll talk more about capabilities-security, including both __object capabilities__ and __reference capabilities__ later.
+
+<a name="fn1">1</a>: Sylvan Clebsch and Sophia Drossopoulou. Fully Concurrent Garbage Collection of Actors on Many-Core Machines. In OOPSLA '13


### PR DESCRIPTION
Fixes GH #148 

I tried both markdown syntax variants for footnotes [1] and [^1] but it didn't work properly and didn't look good. So I rather went with the simple link.

[1] Sylvan Clebsch and Sophia Drossopoulou. Fully Concurrent Garbage Collection of Actors on Many-Core Machines. [opsla237-clebsch.pdf](https://github.com/ponylang/ponylang.github.io/blob/master/media/papers/opsla237-clebsch.pdf)

This would work though: https://stackoverflow.com/questions/25579868/how-to-add-footnotes-to-github-flavoured-markdown
