### PR TITLE
Update break semantics

### DIFF
--- a/expressions/control-structures.md
+++ b/expressions/control-structures.md
@@ -127,7 +127,7 @@ __So is this like an else block on a while loop in Python?__ No, this is very di
 
 Sometimes you want to stop part-way through a loop and give up altogether. Pony has the `break` keyword for this and it is very similar to its counterpart in languages like C++, C# and Python.
 
-`break` immediately exits from the innermost loop it's in. Since the loop has to return a value `break` can take an expression. This is optional and if it's missed out a value of `None` is returned.
+`break` immediately exits from the innermost loop it's in. Since the loop has to return a value `break` can take an expression. This is optional and if it's missed out the value from the `else` block is returned.
 
 Let's have an example. Suppose you want to go through a list of names you're getting from somewhere, looking for either "Jack" or "Jill". If neither of those appear you'll just take the last name you're given and if you're not given any names at all you'll use "Herbert".
 


### PR DESCRIPTION
A `break` with no value now takes its value from the `else` block instead of being an implicit `None`.