### PR TITLE
Update tutorial to show new lambda syntax.

### DIFF
--- a/appendices/examples.md
+++ b/appendices/examples.md
@@ -235,14 +235,14 @@ let dice: Array[U32] = [1, 2, 3, 4, 5, 6]
 actor Main
   fun foo(n:U32): {ref(U32): U32} =>
     var s: Array[U32] = Array[U32].init(n, 1)
-    lambda ref(i:U32)(s): U32 =>
+    {ref(i:U32)(s): U32 =>
       try
         s(0) = s(0) + i
         s(0)
       else
         0
       end
-    end
+    }
 
   new create(env:Env) =>
     var f = foo(5)


### PR DESCRIPTION
This PR updates the tutorial to show the new lambda syntax. It also makes some corrections around some details about lambdas.

See https://github.com/ponylang/ponyc/pull/1400 for the implementation of the change.