### PR TITLE
Update standard library location

### DIFF
--- a/gotchas/garbage-collection.md
+++ b/gotchas/garbage-collection.md
@@ -22,4 +22,4 @@ actor Main
     end
 ```
 
-This program will never garbage collect before exiting. `create` is run as a behavior on actors which means that no garbage collection will occur while it's running. Long loops in behaviors are a good way to exhaust memory. Don't do it. If you want to execute something in such a fashion, use a [Timer](http://www.ponylang.org/ponyc/time-Timer/).
+This program will never garbage collect before exiting. `create` is run as a behavior on actors which means that no garbage collection will occur while it's running. Long loops in behaviors are a good way to exhaust memory. Don't do it. If you want to execute something in such a fashion, use a [Timer](http://stdlib.ponylang.org/time-Timer/).

--- a/gotchas/scheduling.md
+++ b/gotchas/scheduling.md
@@ -17,5 +17,5 @@ be bad_citizen() =>
   end
 ```
 
-That is some seriously bad citizen code that will hog a scheduler thread forever. Call that behavior a few times and your program will grind to a halt. If you find yourself writing code with loops that will run for a long time, stop and rethink your design. Take a look at the [Timer](http://www.ponylang.org/ponyc/time-Timer/) class from the standard library. Combine that together with a counter in your class and you can execute the same behavior repeatedly while yielding your scheduler thread to other actors.
+That is some seriously bad citizen code that will hog a scheduler thread forever. Call that behavior a few times and your program will grind to a halt. If you find yourself writing code with loops that will run for a long time, stop and rethink your design. Take a look at the [Timer](http://stdlib.ponylang.org/time-Timer/) class from the standard library. Combine that together with a counter in your class and you can execute the same behavior repeatedly while yielding your scheduler thread to other actors.
 

--- a/packages/standard-library.md
+++ b/packages/standard-library.md
@@ -4,4 +4,4 @@ The Pony standard library is a collection of packages that can each be used as n
 
 There is also a special package in the standard library called __builtin__. This contains various types that the compiler has to treat specially and are so common that all Pony code needs to know about them. All Pony source files have an implicit `use "builtin"` command. This means all the types defined in the package builtin are automatically available in the type namespace of all Pony source files.
 
-Documentation for the standard library is [available online](http://www.ponylang.org/ponyc/)
+Documentation for the standard library is [available online](http://stdlib.ponylang.org/)

--- a/testing/ponytest.md
+++ b/testing/ponytest.md
@@ -113,4 +113,4 @@ The test's TestHelper is handed to tear_down() and it is permitted to log messag
 
 ## Additional resources
 
-You can learn more about PonyTest specifics by checking out the [API documentation](http://www.ponylang.org/ponyc/ponytest--index/). There's also a [testing section](http://patterns.ponylang.org/testing/index.html) in the [Pony Patterns](http://patterns.ponylang.org/) book.
+You can learn more about PonyTest specifics by checking out the [API documentation](http://stdlib.ponylang.org/ponytest--index/). There's also a [testing section](http://patterns.ponylang.org/testing/index.html) in the [Pony Patterns](http://patterns.ponylang.org/) book.

--- a/where-next/index.md
+++ b/where-next/index.md
@@ -18,7 +18,7 @@ On of the hardest parts of learning a new language is figuring out how to do var
 
 You are going to need to learn the standard library. Some of us prefer to open the source code and explore. If you prefer an online experience, we maintain a version of the standard library documentation online. And you don't have to worry about it going out of date as it is updated on every commit to the ponyc master branch.
 
-[Standard Library Documentation](http://www.ponylang.org/ponyc/)
+[Standard Library Documentation](http://stdlib.ponylang.org/)
 
 ## Pony Users' Mailing List
 


### PR DESCRIPTION
This completements the change in ponylang/ponylang.github.io#50 by @SeanTAllen. I assume that the new stdlib location will be consistent, but neither location has the contents of interest at the moment.