### PR TITLE
update array literal examples

### DIFF
--- a/appendices/examples.md
+++ b/appendices/examples.md
@@ -26,7 +26,7 @@ type Colour is (Black | Blue | Red | Yellow)
 
 primitive ColourList
   fun tag apply(): Array[Colour] =>
-    [Black, Blue, Red, Yellow]
+    [Black; Blue; Red; Yellow]
 
 for colour in ColourList().values() do
 end
@@ -203,8 +203,15 @@ class Test
 ```
 
 ## How to create Arrays with values
+
+Single values can be separated by semicolon or newline.
+
 ```pony
-let dice: Array[U32] = [1, 2, 3, 4, 5, 6]
+let dice: Array[U32] = [1; 2; 3 
+  4 
+  5
+  6
+]
 ```
 
 ## How to modify a lexically captured variable in a closure

--- a/expressions/control-structures.md
+++ b/expressions/control-structures.md
@@ -171,7 +171,7 @@ The Pony `for` loop iterates over a collection of items using an iterator. On ea
 For example to print out all the strings in an array:
 
 ```pony
-for name in ["Bob", "Fred", "Sarah"].values() do
+for name in ["Bob"; "Fred"' "Sarah"].values() do
   env.out.print(name)
 end
 ```
@@ -189,7 +189,7 @@ where T is the type of the objects in the collection. You don't need to worry ab
 You can think of the above example as being equivalent to:
 
 ```pony
-let iterator = ["Bob", "Fred", "Sarah"].values()
+let iterator = ["Bob"; "Fred"; "Sarah"].values()
 while iterator.has_next() do
   let name = iterator.next()
   env.out.print(name)

--- a/pattern-matching/as.md
+++ b/pattern-matching/as.md
@@ -69,9 +69,9 @@ actor Main
     // do something boring here
 
   new create(env: Env) =>
-    foo([as U32: 1, 2, 3])
+    foo([as U32: 1; 2; 3])
     // the compiler would complain about this:
-    //   foo([1, 2, 3])
+    //   foo([1; 2; 3])
 ```
 
 The requested type must be a valid type for the items in the array. Since these types are checked at compile time they are guaranteed to work, so there is no need for the programmer to handle an error condition.

--- a/types/type-aliases.md
+++ b/types/type-aliases.md
@@ -42,7 +42,7 @@ You might also want to iterate over the enum like this to print its name for deb
 ```pony
 primitive ColourList
   fun tag apply(): Array[Colour] =>
-    [Red, Green, Blue]
+    [Red; Green; Blue]
 
 for colour in ColourList().values() do
 end


### PR DESCRIPTION
to the new syntax introduced with pony 12.0 (RFC: https://github.com/ponylang/rfcs/blob/master/text/0037-arrays-as-sequences.md)
which requires semicolon or newline between separate values.