### PR TITLE
Update exceptions.md to encapsulate keywords in `

### DIFF
--- a/expressions/exceptions.md
+++ b/expressions/exceptions.md
@@ -4,7 +4,7 @@ Pony provides a simple exception mechanism to aid in error handling. At any poin
 
 ## Raising and handling errors
 
-An error is raised with the command `error`. Error handlers are declared using the try-else syntax.
+An error is raised with the command `error`. Error handlers are declared using the `try`-`else` syntax.
 
 ```pony
 try
@@ -20,11 +20,11 @@ In the above code `callA()` will always be executed and so will `callB()`. If th
 
 However, if `callB()` returns false, then an error will be raised. At this point, execution will stop and the nearest enclosing error handler will be found and executed. In this example that is, our else block and so `callD()` will be executed.
 
-In either case, execution will then carry on with whatever code comes after the try `end`.
+In either case, execution will then carry on with whatever code comes after the `try end`.
 
-__Do I have to provide an error handler?__ No. The try block will handle any errors regardless. If you don't provide an error handler then no error handling action will be taken - execution will simply continue after the try expression.
+__Do I have to provide an error handler?__ No. The `try` block will handle any errors regardless. If you don't provide an error handler then no error handling action will be taken - execution will simply continue after the `try` expression.
 
-If you want to do something that might raise an error, but you don't care if it does you can just put in it a try block without an else.
+If you want to do something that might raise an error, but you don't care if it does you can just put in it a `try` block without an `else`.
 
 ```pony
 try
@@ -34,7 +34,7 @@ end
 
 __Is there anything my error handler has to do?__ No. If you provide an error handler then it must contain some code, but it is entirely up to you what it does.
 
-__What's the resulting value of a try block?__ The result of a try block is the value of the last statement in the `try` block, or the the value of the last statement in the `else` clause if an error was raised. If an error was raised and there was no `else` clause provided, the result value will be `None`.
+__What's the resulting value of a try block?__ The result of a `try` block is the value of the last statement in the `try` block, or the the value of the last statement in the `else` clause if an error was raised. If an error was raised and there was no `else` clause provided, the result value will be `None`.
 
 
 ## Partial functions
@@ -53,9 +53,9 @@ fun factorial(x: I32): I32 ? =>
   end
 ```
 
-Everywhere that an error can be generated in Pony (an error command, a call to a partial function, or certain built-in language constructs) must appear within a try block or a function that is marked as partial. This is checked at compile time, ensuring that an error cannot escape handling and crash the program.
+Everywhere that an error can be generated in Pony (an error command, a call to a partial function, or certain built-in language constructs) must appear within a `try` block or a function that is marked as partial. This is checked at compile time, ensuring that an error cannot escape handling and crash the program.
 
-Prior to Pony 0.16.0, call sites of partial functions were not required to be marked with a '?'. This often led to confusion about the possibilities for control flow when reading code. Having every partial function call site clearly marked makes it very easy for the reader to immediately understand everywhere that a block of code may jump away to the nearest error handler, making the possible control flow paths more obvious and explicit.
+Prior to Pony 0.16.0, call sites of partial functions were not required to be marked with a `?`. This often led to confusion about the possibilities for control flow when reading code. Having every partial function call site clearly marked makes it very easy for the reader to immediately understand everywhere that a block of code may jump away to the nearest error handler, making the possible control flow paths more obvious and explicit.
 
 ## Partial constructors and behaviours
 
@@ -67,7 +67,7 @@ Behaviours are also executed asynchronously and so cannot be partial for the sam
 
 ## Try-then blocks
 
-In addition to an `else` error handler, a try command can have a `then` block. This is executed after the rest of the try, whether or not an error is raised or handled. Expanding our example from earlier:
+In addition to an `else` error handler, a `try` command can have a `then` block. This is executed after the rest of the `try`, whether or not an error is raised or handled. Expanding our example from earlier:
 
 ```pony
 try
@@ -81,11 +81,11 @@ then
 end
 ```
 
-The callE() will always be executed. If callB() returns true then the sequence executed is callA(), callB(), callC(), callE(). If callB() returns false then the sequence executed is callA(), callB(), callD(), callE().
+The `callE()` will always be executed. If `callB()` returns true then the sequence executed is `callA()`, `callB()`, `callC()`, `callE()`. If `callB()` returns false then the sequence executed is `callA()`, `callB()`, `callD()`, `callE()`.
 
-__Do I have to have an else error handler to have a then block?__ No. You can have a try-then block without an else if you like.
+__Do I have to have an else error handler to have a then block?__ No. You can have a `try`-`then` block without an `else` if you like.
 
-__Will my then block really always be executed, even if I return inside the try?__ Yes, your `then` expression will __always__ be executed when the try block is complete. The only way it won't be is if the try never completes (due to an infinite loop), the machine is powered off, or the process is killed (and then, maybe).
+__Will my then block really always be executed, even if I return inside the try?__ Yes, your `then` expression will __always__ be executed when the `try` block is complete. The only way it won't be is if the `try` never completes (due to an infinite loop), the machine is powered off, or the process is killed (and then, maybe).
 
 ## With blocks
 


### PR DESCRIPTION
A few of the `try`'s and some other keywords/code snippets had no ticks around them, this should (hopefully) catch them all (oh god I used a Pokemon reference -.- I feel so bad, sorry!)

To give context:
@SeanTAllen Licenser: are you saying sometimes it was ` around it and sometimes it doesn't?
@SeanTAllen if yes, then yes, please make keywords always have ` around them where you find they don't