### PR TITLE
Add section about literals

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -11,6 +11,7 @@
   * [Type Aliases](types/type-aliases.md)
   * [Type Expressions](types/type-expressions.md)
 * [Chapter 3: Expressions](expressions/index.md)
+  * [Literals](expressions/literals.md)
   * [Variables](expressions/variables.md)
   * [Infix Operators](expressions/infix-ops.md)
   * [Control Structures](expressions/control-structures.md)

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -1,0 +1,299 @@
+# Literals
+
+***What do we want?***
+
+Values!
+
+**Where do we want them?***
+
+In our pony programs!
+
+**Say no more**
+
+Every programming language has literals to encode values of certain types,
+and so does Pony.
+
+In pony you can express booleans, numeric types, characters, strings
+and arrays as literals.
+
+## Bool Literals
+
+There is ``true``, there is ``false``. That's it.
+
+## Numeric Literals
+
+Numeric literals can be used to encode any signed or unsigned integer
+or floating point number.
+
+In most cases pony is able to infer the concrete type of the literal from
+the context where it is used (Assignment to a field or local variable,
+as argument to a method/behavior call).
+
+It is possible to help the compiler determine the concrete type of the literal
+using a constructor of one of the numeric types:
+
+ * U8, U16, U32, U64, U128, USize, ULong
+ * I8, I16, I32, I64, I128, ISize, ILong
+ * F32, F64
+
+```pony
+let my_explicit_unsigned: U32 = 42_000
+let my_constructor_unsigned = U8(1)
+let my_constructor_float = F64(1.234)
+```
+
+Integer literals can be given as decimal, hexadecimal
+or binary:
+
+```pony
+let my_decimal_int: I32 = 1024
+let my_hexadecimal_int: I32 = 0x400
+let my_binary_int: I32 = 0b10000000000
+```
+
+Floating Point literals are expressed as standard floating point 
+or scientific notation:
+
+```pony
+let my_double_precision_float: F64 = 0.009999999776482582092285156250
+let my_scientific_float: F32 = 42.12e-4
+```
+
+## Character Literals
+
+Character literals are enclosed with single quotes (``'``).
+
+They are used to encode single byte characters 
+but can be coerced to any numeric type:
+
+```pony
+let big_a: U8 = 'A'
+let hex_escaped_char: U8 = '\x41'
+let newline: U32 = '\n'
+```
+
+The following escape sequences are supported:
+
+* ``\x4F`` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
+* ``\a``, ``\b``, ``\e``, ``\f``, ``\n``, ``\r``, ``\t``, ``\v``, ``\\``, ``\0``, ``\"``
+
+The empty character literal ``''`` is treated as ``0``.
+
+
+## String Literals
+
+String literals are enclosed by single quotes ``"`` or triple quotes ``"""``.
+They can contain any unicode characters and various escape sequences:
+
+* ``\u00FE`` unicode escape sequence with 4 hex digits encoding one code point
+* ``\u10FFFE`` unicode escape sequence with 6 hex digits encoding one code point
+* ``\x4F`` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
+* ``\a``, ``\b``, ``\e``, ``\f``, ``\n``, ``\r``, ``\t``, ``\v``, ``\\``, ``\0``, ``\"``
+
+Each escape sequence encodes a full character, not byte.
+
+```pony
+
+    let pony = "🐎"
+    let pony_hex_escaped = "p\xF6n\xFF"
+    let pony_unicode_escape = "\U01F40E"
+
+    env.out.print(pony + " " + pony_hex_escaped + " " + pony_unicode_escape)
+    for b in pony.values() do
+      env.out.print(Format.int[U8](b, FormatHex))
+    end
+
+```
+
+All string literals support multiline strings:
+
+```pony
+
+let stacked_ponies = "
+🐎
+🐎
+🐎
+"
+```
+
+### Triple quoted Strings
+
+For embedding multi-line text in string literals,
+there are triple quoted strings.
+
+```pony
+let triple_quoted_string_docs =
+  """
+  Triple quoted strings are the way to go for long multiline text.
+  They are extensively used as docstrings which are turned into api documentation.
+
+  They get some special treatment, in order to keep pony code readable:
+
+  * The string literal starts on the line after the opening triple quote.
+  * Common indentation is removed from the string literal
+    so it can be conveniently aligned with the enclosing indentation
+    e.g. each line of this literal will get its first two whitespaces removed
+  * Whitespace after the opening and before the closing triple quote will be
+    removed as well. The first line will be completely removed.
+    if it only contains whitespace.
+    e.g. this strings first character is ``T`` not ``\n``.
+  """
+```
+
+## Array Literals
+
+Array literals are enclosed by square brackets.
+Array literal elements can be any kind of expressions.
+They are separated by semicolon or newline:
+
+```pony
+let my_literal_array = [ "first"; "second"
+  "third one on a new line"]
+```
+
+Empty array literals are not supported.
+Use ``recover val Array(0) end`` instead.
+
+### Type inference
+
+
+The type of the literal array expression is Always ``Array[T] ref``
+where ``T`` (the type of the elements) is inferred as 
+the union type of all the element types:
+
+```pony
+let my_heterogenous_array: Array[(U64|String)] ref = [
+  U64(42)
+  "42"
+  U64.min_value()
+]
+```
+
+In the above example the resulting array type will be
+``Array[(U64|String)] ref`` because the array contains
+``String`` and ``U64`` elements.
+
+It is possible to give the literal a hint on what kind of type it should
+coerce the array literal to. In the above example
+we might only want an ``Array[Stringable] ref``. ``Stringable`` is a trait
+that both ``String`` and ``U64`` implement.
+
+In order to do so, add an ``as`` Expression
+defining the desired Array element type right after the opening square bracket
+delimited by a colon:
+
+```pony
+let my_stringable_array: Array[Stringable] ref =
+  [as Stringable:
+    U64(0xFFEF)
+    "0xFFEF"
+    U64(1 + 1)
+  ]
+```
+
+This Array literal is coerced to be an ``Array[Stringable] ref`` according to
+the ``as`` expression.
+
+Inferring the element type from the type of the local variable
+or field it is assigned to is not yet possible:
+
+```pony
+// does not compile
+let my_stringable_array: Array[Stringable] =
+  [
+    U64(0xA)
+    "0xA"
+  ]
+```
+
+### Arrays and References
+
+*This section will lead you down the rabbit-hole of
+[Reference capabilities](../capabilities/index.md).
+It is advised to make yourself familiar with that concept first before reading this.*
+
+To be 100% technically correct, array literal elements are inferred
+to be the alias of the the actual element type.
+If all elements are of type ``T`` the array literal will be inferred as
+``Array[T!]`` that is as an array of aliases of the type ``T``.
+
+***Why is that?***
+
+Arrays store references to their elements, not the elements themselves.
+There might exist another reference somewhere else to an array element.
+In order to safely use ``Array`` with elements of all types and
+reference capabilities (including ``iso``), the only possibility is to store
+the elements as an alias to that type: ``T!``
+
+To safely create an array literal of type ``Array[T]`` it is necessary
+to use elements of type ``T^``, an ephemeral type of ``T``;
+A ``T`` that is not assigned to any variable yet.
+"Consuming" a variable returns an ephemeral type,
+all constructors return ephemeral types, and other literal expressions work
+the same:
+
+```pony
+let ref = U64(123)
+let safe_array: Array[U64 val] =
+  [
+    consume ref     // consuming a variable
+    U64.create(1)   // constructor
+    U64.min_value() // constructor
+  ]
+```
+
+Most of the time constructing array literals is not a problem,
+especially when using only literal elements (Strings, Numbers).
+These have the reference capability ``val`` which is safe to alias multiple
+times and whose aliases are safe to also be ``val``.
+So this just works:
+
+```pony
+let safe_array: Array[String val] = [
+  "A"
+  "B"
+  "C"
+]
+```
+
+Because it is equivalent to this:
+
+```pony
+let explicit_safe_array: Array[String val!] = [
+  "A"
+  "B"
+  "C"
+]
+```
+
+#### More Details
+
+Consider the following example:
+
+```pony
+// does not compile
+let s: String iso = recover iso String(0) end
+let array: Array[String iso] = [s]
+```
+
+*It does not work. Why?*
+
+The variable ``s`` is of type ``String iso``,
+it has the reference capability ``iso`` which allows only 1 reference
+to this object. The only way to safely refer to such an ``iso`` object
+with another variable is as type ``String tag`` (technically ``String iso!``)
+which only allows to get its identity, nothing more.
+
+The Array literal is thus inferred as ``Array[String tag]``, not ``Array[iso]``
+because it creates additional references/aliases to its elements.
+This is not the type specified on the left-hand side, so it errors.
+
+These are valid ways to construct Arrays of ``iso`` elements without
+getting into trouble with the compiler:
+
+```pony
+let s: String iso = recover iso String(0) end
+let tag_array: Array[String tag] = [s]          // use the alias type for the array
+
+let iso_array: Array[String iso] = [consume s]  // consume the iso variable
+```

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -6,31 +6,25 @@ Values!
 
 **Where do we want them?***
 
-In our pony programs!
+In our Pony programs!
 
 **Say no more**
 
-Every programming language has literals to encode values of certain types,
-and so does Pony.
+Every programming language has literals to encode values of certain types, and so does Pony.
 
-In pony you can express booleans, numeric types, characters, strings
-and arrays as literals.
+In Pony you can express booleans, numeric types, characters, strings and arrays as literals.
 
 ## Bool Literals
 
-There is ``true``, there is ``false``. That's it.
+There is `true`, there is `false`. That's it.
 
 ## Numeric Literals
 
-Numeric literals can be used to encode any signed or unsigned integer
-or floating point number.
+Numeric literals can be used to encode any signed or unsigned integer or floating point number.
 
-In most cases pony is able to infer the concrete type of the literal from
-the context where it is used (Assignment to a field or local variable,
-as argument to a method/behavior call).
+In most cases Pony is able to infer the concrete type of the literal from the context where it is used (e.g. assignment to a field or local variable or as argument to a method/behaviour call).
 
-It is possible to help the compiler determine the concrete type of the literal
-using a constructor of one of the numeric types:
+It is possible to help the compiler determine the concrete type of the literal using a constructor of one of the numeric types:
 
  * U8, U16, U32, U64, U128, USize, ULong
  * I8, I16, I32, I64, I128, ISize, ILong
@@ -42,8 +36,7 @@ let my_constructor_unsigned = U8(1)
 let my_constructor_float = F64(1.234)
 ```
 
-Integer literals can be given as decimal, hexadecimal
-or binary:
+Integer literals can be given as decimal, hexadecimal or binary:
 
 ```pony
 let my_decimal_int: I32 = 1024
@@ -51,8 +44,7 @@ let my_hexadecimal_int: I32 = 0x400
 let my_binary_int: I32 = 0b10000000000
 ```
 
-Floating Point literals are expressed as standard floating point 
-or scientific notation:
+Floating Point literals are expressed as standard floating point or scientific notation:
 
 ```pony
 let my_double_precision_float: F64 = 0.009999999776482582092285156250
@@ -61,34 +53,29 @@ let my_scientific_float: F32 = 42.12e-4
 
 ## Character Literals
 
-Character literals are enclosed with single quotes (``'``).
+Character literals are enclosed with single quotes (`'`).
 
-They are used to encode single byte characters 
-but can be coerced to any numeric type:
+They are used to encode single byte characters but can be coerced to any numeric type:
 
 ```pony
 let big_a: U8 = 'A'
-let hex_escaped_char: U8 = '\x41'
+let hex_escaped_big_a: U8 = '\x41'
 let newline: U32 = '\n'
 ```
 
 The following escape sequences are supported:
 
-* ``\x4F`` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
-* ``\a``, ``\b``, ``\e``, ``\f``, ``\n``, ``\r``, ``\t``, ``\v``, ``\\``, ``\0``, ``\"``
-
-The empty character literal ``''`` is treated as ``0``.
-
+* `\x4F` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
+* `\a`, `\b`, `\e`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\0`, `\"`
 
 ## String Literals
 
-String literals are enclosed by single quotes ``"`` or triple quotes ``"""``.
-They can contain any kind characters and various escape sequences:
+String literals are enclosed with single quotes `"` or triple quotes `"""`. They can contain any kind of bytes and various escape sequences:
 
-* ``\u00FE`` unicode escape sequence with 4 hex digits encoding one code point
-* ``\u10FFFE`` unicode escape sequence with 6 hex digits encoding one code point
-* ``\x4F`` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
-* ``\a``, ``\b``, ``\e``, ``\f``, ``\n``, ``\r``, ``\t``, ``\v``, ``\\``, ``\0``, ``\"``
+* `\u00FE` unicode escape sequence with 4 hex digits encoding one code point
+* `\u10FFFE` unicode escape sequence with 6 hex digits encoding one code point
+* `\x4F` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
+* `\a`, `\b`, `\e`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\0`, `\"`
 
 Each escape sequence encodes a full character, not byte.
 
@@ -118,8 +105,7 @@ let stacked_ponies = "
 
 ### String Literals and Encodings
 
-String Literals contain the bytes that were read from their source code file.
-Their actual value thus depends on the encoding of the source code file:
+String Literals contain the bytes that were read from their source code file. Their actual value thus depends on the encoding of their source.
 
 Consider the following example:
 
@@ -127,19 +113,11 @@ Consider the following example:
 let u_umlaut = "ü"
 ```
 
-If the file containing this code is encoded as *UTF-8* 
-the byte-value of ``u_umlaut`` will be: ``\xc3\xbc``.
-If the file is encoded with *ISO-8559-1* (Latin-1) its value is ``\xfc``.
-
-``String`` works best with *UTF-8* as it has methods to deal with unicode
-codepoints which expects *UTF-8*.
-
-So it is advised to encode you pony source code in *UTF-8*.
+If the file containing this code is encoded as *UTF-8* the byte-value of `u_umlaut` will be: `\xc3\xbc`. If the file is encoded with *ISO-8559-1* (Latin-1) its value will be `\xfc`.
 
 ### Triple quoted Strings
 
-For embedding multi-line text in string literals,
-there are triple quoted strings.
+For embedding multi-line text in string literals, there are triple quoted strings.
 
 ```pony
 let triple_quoted_string_docs =
@@ -154,68 +132,56 @@ let triple_quoted_string_docs =
     so it can be conveniently aligned with the enclosing indentation
     e.g. each line of this literal will get its first two whitespaces removed
   * Whitespace after the opening and before the closing triple quote will be
-    removed as well. The first line will be completely removed.
-    if it only contains whitespace.
-    e.g. this strings first character is ``T`` not ``\n``.
+    removed as well. The first line will be completely removed if it only 
+    contains whitespace. e.g. this strings first character is `T` not `\n`.
   """
 ```
 
 ## Array Literals
 
-Array literals are enclosed by square brackets.
-Array literal elements can be any kind of expressions.
-They are separated by semicolon or newline:
+Array literals are enclosed by square brackets. Array literal elements can be any kind of expressions. They are separated by semicolon or newline:
 
 ```pony
-let my_literal_array = [ "first"; "second"
-  "third one on a new line"]
+let my_literal_array =
+  [
+    "first"; "second"
+    "third one on a new line"
+  ]
 ```
 
-Empty array literals are not supported.
-Use ``recover val Array(0) end`` instead.
+Empty array literals are not supported. Use `recover val Array(0) end` instead.
 
 ### Type inference
 
-
-The type of the literal array expression is Always ``Array[T] ref``
-where ``T`` (the type of the elements) is inferred as 
-the union type of all the element types:
+The type of the literal array expression is Always `Array[T] ref` where `T` (the type of the elements) is inferred as the union of all the element types:
 
 ```pony
-let my_heterogenous_array: Array[(U64|String)] ref = [
-  U64(42)
-  "42"
-  U64.min_value()
-]
+let my_heterogenous_array: Array[(U64|String)] ref = 
+  [
+    U64(42)
+    "42"
+    U64.min_value()
+  ]
 ```
 
-In the above example the resulting array type will be
-``Array[(U64|String)] ref`` because the array contains
-``String`` and ``U64`` elements.
+In the above example the resulting array type will be `Array[(U64|String)] ref` because the array contains `String` and `U64` elements.
 
-It is possible to give the literal a hint on what kind of type it should
-coerce the array literal to. In the above example
-we might only want an ``Array[Stringable] ref``. ``Stringable`` is a trait
-that both ``String`` and ``U64`` implement.
+It is possible to give the literal a hint on what kind of type it should coerce the array literal to. In the above example we might only want an `Array[Stringable] ref`. `Stringable` is a trait that both `String` and `U64` implement.
 
-In order to do so, add an ``as`` Expression
-defining the desired Array element type right after the opening square bracket
-delimited by a colon:
+In order to do so an `as` Expression defining the desired Array element type needs to be added right after the opening square bracket, delimited by a colon:
 
 ```pony
 let my_stringable_array: Array[Stringable] ref =
-  [as Stringable:
+  [ as Stringable:
     U64(0xFFEF)
     "0xFFEF"
     U64(1 + 1)
   ]
 ```
 
-This Array literal is coerced to be an ``Array[Stringable] ref`` according to
-the ``as`` expression.
+This Array literal is coerced to be an `Array[Stringable] ref` according to the `as` expression.
 
-Inferring the element type from the type of the local variable
-or field it is assigned to is not yet possible:
+Inferring the element type from the type of the local variable or field it is assigned to is not yet possible:
 
 ```pony
 // does not compile
@@ -228,92 +194,6 @@ let my_stringable_array: Array[Stringable] =
 
 ### Arrays and References
 
-*This section will lead you down the rabbit-hole of
-[Reference capabilities](../capabilities/index.md).
-It is advised to make yourself familiar with that concept first before reading this.*
+Constructing an Array with a literal creates new references to its elements. Thus, to be 100% technically correct, array literal elements are inferred to be the alias of the actual element type. If all elements are of type `T` the array literal will be inferred as `Array[T!] ref` that is as an array of aliases of the type `T`. 
 
-To be 100% technically correct, array literal elements are inferred
-to be the alias of the the actual element type.
-If all elements are of type ``T`` the array literal will be inferred as
-``Array[T!]`` that is as an array of aliases of the type ``T``.
-
-***Why is that?***
-
-Arrays store references to their elements, not the elements themselves.
-There might exist another reference somewhere else to an array element.
-In order to safely use ``Array`` with elements of all types and
-reference capabilities (including ``iso``), the only possibility is to store
-the elements as an alias to that type: ``T!``
-
-To safely create an array literal of type ``Array[T]`` it is necessary
-to use elements of type ``T^``, an ephemeral type of ``T``;
-A ``T`` that is not assigned to any variable yet.
-"Consuming" a variable returns an ephemeral type,
-all constructors return ephemeral types, and other literal expressions work
-the same:
-
-```pony
-let ref = U64(123)
-let safe_array: Array[U64 val] =
-  [
-    consume ref     // consuming a variable
-    U64.create(1)   // constructor
-    U64.min_value() // constructor
-  ]
-```
-
-Most of the time constructing array literals is not a problem,
-especially when using only literal elements (Strings, Numbers).
-These have the reference capability ``val`` which is safe to alias multiple
-times and whose aliases are safe to also be ``val``.
-So this just works:
-
-```pony
-let safe_array: Array[String val] = [
-  "A"
-  "B"
-  "C"
-]
-```
-
-Because it is equivalent to this:
-
-```pony
-let explicit_safe_array: Array[String val!] = [
-  "A"
-  "B"
-  "C"
-]
-```
-
-#### More Details
-
-Consider the following example:
-
-```pony
-// does not compile
-let s: String iso = recover iso String(0) end
-let array: Array[String iso] = [s]
-```
-
-*It does not work. Why?*
-
-The variable ``s`` is of type ``String iso``,
-it has the reference capability ``iso`` which allows only 1 reference
-to this object. The only way to safely refer to such an ``iso`` object
-with another variable is as type ``String tag`` (technically ``String iso!``)
-which only allows to get its identity, nothing more.
-
-The Array literal is thus inferred as ``Array[String tag]``, not ``Array[iso]``
-because it creates additional references/aliases to its elements.
-This is not the type specified on the left-hand side, so it errors.
-
-These are valid ways to construct Arrays of ``iso`` elements without
-getting into trouble with the compiler:
-
-```pony
-let s: String iso = recover iso String(0) end
-let tag_array: Array[String tag] = [s]          // use the alias type for the array
-
-let iso_array: Array[String iso] = [consume s]  // consume the iso variable
-```
+It is thus necessary to use elements that can have more than one reference of the same type (e.g. types with `val` or `ref` capability) or use ephemeral types for other capabilities (as returned from [constructors](../types/classes.md#constructors) or the [consume expression](../capabilities/consume-and-destructive-read.md)).

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -83,7 +83,7 @@ The empty character literal ``''`` is treated as ``0``.
 ## String Literals
 
 String literals are enclosed by single quotes ``"`` or triple quotes ``"""``.
-They can contain any unicode characters and various escape sequences:
+They can contain any kind characters and various escape sequences:
 
 * ``\u00FE`` unicode escape sequence with 4 hex digits encoding one code point
 * ``\u10FFFE`` unicode escape sequence with 6 hex digits encoding one code point
@@ -115,6 +115,26 @@ let stacked_ponies = "
 🐎
 "
 ```
+
+### String Literals and Encodings
+
+String Literals contain the bytes that were read from their source code file.
+Their actual value thus depends on the encoding of the source code file:
+
+Consider the following example:
+
+```pony
+let u_umlaut = "ü"
+```
+
+If the file containing this code is encoded as *UTF-8* 
+the byte-value of ``u_umlaut`` will be: ``\xc3\xbc``.
+If the file is encoded with *ISO-8559-1* (Latin-1) its value is ``\xfc``.
+
+``String`` works best with *UTF-8* as it has methods to deal with unicode
+codepoints which expects *UTF-8*.
+
+So it is advised to encode you pony source code in *UTF-8*.
 
 ### Triple quoted Strings
 

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -55,18 +55,27 @@ let my_scientific_float: F32 = 42.12e-4
 
 Character literals are enclosed with single quotes (`'`).
 
-They are used to encode single byte characters but can be coerced to any numeric type:
+Character literals, unlike String literals, encode to a single numeric value. Usually this is a single byte, a `U8`. But they can be coerced to any integer type:
 
 ```pony
-let big_a: U8 = 'A'
-let hex_escaped_big_a: U8 = '\x41'
-let newline: U32 = '\n'
+let big_a: U8 = 'A'                 // 65
+let hex_escaped_big_a: U8 = '\x41'  // 65
+let newline: U32 = '\n'             // 10
 ```
 
 The following escape sequences are supported:
 
-* `\x4F` hex escape sequence for unicode letters with 2 hex digits (up to 0xFF)
+* `\x4F` hex escape sequence with 2 hex digits (up to 0xFF)
 * `\a`, `\b`, `\e`, `\f`, `\n`, `\r`, `\t`, `\v`, `\\`, `\0`, `\"`
+
+### Multibyte Character literals
+
+It is possible to have character literals that contain multiple characters. The resulting integer value is constructed byte by byte with each character representing a single byte in the resulting integer, the last character being the least significant byte:
+
+```pony
+let multiByte: U64 = 'ABCD' // 0x41424344
+```
+
 
 ## String Literals
 

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -151,7 +151,7 @@ let triple_quoted_string_docs =
 Array literals are enclosed by square brackets. Array literal elements can be any kind of expressions. They are separated by semicolon or newline:
 
 ```pony
-let myLiteralArray =
+let my_literal_array =
   [
     "first"; "second"
     "third one on a new line"
@@ -163,7 +163,7 @@ let myLiteralArray =
 If the type of the array is not specified, the resulting type of the literal array expression is `Array[T] ref` where `T` (the type of the elements) is inferred as the union of all the element types:
 
 ```pony
-let myHeterogenousArray = 
+let my_heterogenous_array = 
   [
     U64(42)
     "42"
@@ -176,19 +176,19 @@ In the above example the resulting array type will be `Array[(U64|String)] ref` 
 If the variable or call argument the array literal is assigned to has a type, the literal is coerced to that type:
 
 ```pony
-let myStringableArray: Array[Stringable] ref =
+let my_stringable_array: Array[Stringable] ref =
   [
     U64(0xA)
     "0xA"
   ]
 ```
 
-Here `myStringableArray` is coerced to `Array[Stringable] ref`. This works because `Stringable` is a trait that both `String` and `U64` implement.
+Here `my_stringable_array` is coerced to `Array[Stringable] ref`. This works because `Stringable` is a trait that both `String` and `U64` implement.
 
 It is also possible to return an Array with a different [Reference Capability](../capabilities/index.md) than `ref` just by specifying it on the type:
 
 ```pony
-let myImmutableArray: Array[Stringable] val =
+let my_immutable_array: Array[Stringable] val =
   [
     U64(0xBEEF)
     "0xBEEF"
@@ -202,7 +202,7 @@ This way array literals can be used for creating Arrays of any [Reference Capabi
 It is also possible to give the literal a hint on what kind of type it should coerce the array elements to using an `as` Expression. The expression with the desired Array element type needs to be added right after the opening square bracket, delimited by a colon:
 
 ```pony
-let myStringableArray =
+let my_as_array =
   [ as Stringable:
     U64(0xFFEF)
     "0xFFEF"

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -185,7 +185,7 @@ let my_stringable_array: Array[Stringable] ref =
 
 Here `my_stringable_array` is coerced to `Array[Stringable] ref`. This works because `Stringable` is a trait that both `String` and `U64` implement.
 
-It is also possible to return an Array with a different [Reference Capability](../capabilities/index.md) than `ref` just by specifying it on the type:
+It is also possible to return an array with a different [Reference Capability](../capabilities/index.md) than `ref` just by specifying it on the type:
 
 ```pony
 let my_immutable_array: Array[Stringable] val =
@@ -195,14 +195,14 @@ let my_immutable_array: Array[Stringable] val =
   ]
 ```
 
-This way array literals can be used for creating Arrays of any [Reference Capability](../capabilities/index.md).
+This way array literals can be used for creating arrays of any [Reference Capability](../capabilities/index.md).
 
 ### `As` Expression
 
-It is also possible to give the literal a hint on what kind of type it should coerce the array elements to using an `as` Expression. The expression with the desired Array element type needs to be added right after the opening square bracket, delimited by a colon:
+It is also possible to give the literal a hint on what kind of type it should coerce the array elements to using an `as` Expression. The expression with the desired array element type needs to be added right after the opening square bracket, delimited by a colon:
 
 ```pony
-let my_as_array =
+let my_as_array: Array[Stringable] ref =
   [ as Stringable:
     U64(0xFFEF)
     "0xFFEF"
@@ -210,10 +210,12 @@ let my_as_array =
   ]
 ```
 
-This Array literal is coerced to be an `Array[Stringable] ref` according to the `as` expression.
+This array literal is coerced to be an `Array[Stringable] ref` according to the `as` expression.
+
+If a type is specified on the left-hand side, it needs to exactly match the type in the `as` expression.
 
 ### Arrays and References
 
-Constructing an Array with a literal creates new references to its elements. Thus, to be 100% technically correct, array literal elements are inferred to be the alias of the actual element type. If all elements are of type `T` the array literal will be inferred as `Array[T!] ref` that is as an array of aliases of the type `T`. 
+Constructing an array with a literal creates new references to its elements. Thus, to be 100% technically correct, array literal elements are inferred to be the alias of the actual element type. If all elements are of type `T` the array literal will be inferred as `Array[T!] ref` that is as an array of aliases of the type `T`. 
 
 It is thus necessary to use elements that can have more than one reference of the same type (e.g. types with `val` or `ref` capability) or use ephemeral types for other capabilities (as returned from [constructors](../types/classes.md#constructors) or the [consume expression](../capabilities/consume-and-destructive-read.md)).

--- a/expressions/literals.md
+++ b/expressions/literals.md
@@ -151,21 +151,19 @@ let triple_quoted_string_docs =
 Array literals are enclosed by square brackets. Array literal elements can be any kind of expressions. They are separated by semicolon or newline:
 
 ```pony
-let my_literal_array =
+let myLiteralArray =
   [
     "first"; "second"
     "third one on a new line"
   ]
 ```
 
-Empty array literals are not supported. Use `recover val Array(0) end` instead.
-
 ### Type inference
 
-The type of the literal array expression is Always `Array[T] ref` where `T` (the type of the elements) is inferred as the union of all the element types:
+If the type of the array is not specified, the resulting type of the literal array expression is `Array[T] ref` where `T` (the type of the elements) is inferred as the union of all the element types:
 
 ```pony
-let my_heterogenous_array: Array[(U64|String)] ref = 
+let myHeterogenousArray = 
   [
     U64(42)
     "42"
@@ -175,12 +173,36 @@ let my_heterogenous_array: Array[(U64|String)] ref =
 
 In the above example the resulting array type will be `Array[(U64|String)] ref` because the array contains `String` and `U64` elements.
 
-It is possible to give the literal a hint on what kind of type it should coerce the array literal to. In the above example we might only want an `Array[Stringable] ref`. `Stringable` is a trait that both `String` and `U64` implement.
-
-In order to do so an `as` Expression defining the desired Array element type needs to be added right after the opening square bracket, delimited by a colon:
+If the variable or call argument the array literal is assigned to has a type, the literal is coerced to that type:
 
 ```pony
-let my_stringable_array: Array[Stringable] ref =
+let myStringableArray: Array[Stringable] ref =
+  [
+    U64(0xA)
+    "0xA"
+  ]
+```
+
+Here `myStringableArray` is coerced to `Array[Stringable] ref`. This works because `Stringable` is a trait that both `String` and `U64` implement.
+
+It is also possible to return an Array with a different [Reference Capability](../capabilities/index.md) than `ref` just by specifying it on the type:
+
+```pony
+let myImmutableArray: Array[Stringable] val =
+  [
+    U64(0xBEEF)
+    "0xBEEF"
+  ]
+```
+
+This way array literals can be used for creating Arrays of any [Reference Capability](../capabilities/index.md).
+
+### `As` Expression
+
+It is also possible to give the literal a hint on what kind of type it should coerce the array elements to using an `as` Expression. The expression with the desired Array element type needs to be added right after the opening square bracket, delimited by a colon:
+
+```pony
+let myStringableArray =
   [ as Stringable:
     U64(0xFFEF)
     "0xFFEF"
@@ -189,17 +211,6 @@ let my_stringable_array: Array[Stringable] ref =
 ```
 
 This Array literal is coerced to be an `Array[Stringable] ref` according to the `as` expression.
-
-Inferring the element type from the type of the local variable or field it is assigned to is not yet possible:
-
-```pony
-// does not compile
-let my_stringable_array: Array[Stringable] =
-  [
-    U64(0xA)
-    "0xA"
-  ]
-```
 
 ### Arrays and References
 


### PR DESCRIPTION
it covers boolean, numeric, character, string and array literals.

Please consider this as a suggestions and feel free to cut, scramble and criticize my writing.
I take no pride from my writing, so roast me. :)

### Concerns
* it might go a little bit too much into detail on array literals and type inference
* it says string literals can contain any unicode characters (which works for me (UTF-8 source file, pony playground) but was reported from several sources that pony does not)