### PR TITLE
ignore special characters in search

### DIFF
--- a/book.json
+++ b/book.json
@@ -5,5 +5,8 @@
         "lunr@1.2.0"
     ],
     "pluginsConfig": {
+        "lunr": {
+            "ignoreSpecialCharacters": true
+        }
     }
 }


### PR DESCRIPTION
this is a workaround for https://github.com/GitbookIO/plugin-lunr/issues/3 and should fix the issue mentioned on the user list, which was introduces by the literals section containing a caroussel horse emoji. (my bad)