### PR TITLE
fix fizzbuzz example for rfc0048

### DIFF
--- a/pattern-matching/case-functions.md
+++ b/pattern-matching/case-functions.md
@@ -79,7 +79,7 @@ actor Main
         env.out.print(FizzBuzz.fizz_buzz(x)? as String)
       end
       let lines = FizzBuzz.fizz_buzz(Range[U64](1, 101))? as Array[String]
-      env.out.print("\n".join(lines))
+      env.out.print("\n".join(lines.values()))
     end
 ```
 


### PR DESCRIPTION
`String.join` argument was changed. and it cause compilation error.
https://github.com/ponylang/rfcs/blob/master/text/0048-change-String-join-to-take-iterable.md

before

```
Error:
    _/main.pony:26:31: argument not a subtype of parameter
      env.out.print("\n".join(lines))
                              ^
    Info:
    _/main.pony:25:62: Array[String val] ref is not a subtype of Iterator[Stringable box] ref: it has no method 'has_next'
          let lines = FizzBuzz.fizz_buzz(Range[U64](1, 101))? as Array[String]
                                                                 ^
    _/main.pony:25:62: Array[String val] ref is not a subtype of Iterator[Stringable box] ref: it has no method 'next'
          let lines = FizzBuzz.fizz_buzz(Range[U64](1, 101))? as Array[String]
```

after

```
Generating
 Reachability
 Selector painting
 Data prototypes
 Data types
 Function prototypes
 Functions
 Descriptors
Optimising
Writing ./pom.o
Linking ./pom
```