### PR TITLE
use gitbook plugin to add button to run code sample

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@ site/
 .DS_Store
 *.sublime-project
 *.sublime-workspace
+_book/
+node_modules/

--- a/book.json
+++ b/book.json
@@ -3,7 +3,7 @@
         "footnote-string-to-number",
         "highlight",
         "lunr@1.2.0",
-        "run-code-button-pony"
+        "run-code-button-ponylang"
     ],
     "pluginsConfig": {
         "lunr": {

--- a/book.json
+++ b/book.json
@@ -2,6 +2,7 @@
     "plugins": [
         "footnote-string-to-number",
         "highlight",
+        "lunr@1.2.0",
         "run-code-button-pony"
     ],
     "pluginsConfig": {

--- a/book.json
+++ b/book.json
@@ -2,7 +2,7 @@
     "plugins": [
         "footnote-string-to-number",
         "highlight",
-        "lunr@1.2.0"
+        "run-code-button-pony"
     ],
     "pluginsConfig": {
         "lunr": {


### PR DESCRIPTION
This add a GitBook plugin to add a button to send code samples to the pony playground. There is not much to see in this request because it just add a GitBook plugin that can be seen [here](https://github.com/codec-abc/gitbook-plugin-copy-code-button/blob/master/book/toggle.js). I used [this plugin](https://github.com/WebEngage/gitbook-plugin-copy-code-button) as a base for my own. Basically it works the following way:

It find each code sample in the page and a button near it. When the button is clicked, I retrieve the code in the sample (in a ugly way I think, but I am no Js expert) created a gist of it -using Github API- and finally redirect the page to the playground with the newly created gist.

The drawbacks are the following:
* It change the current page URL (While reader will probably want to open it in a new tab/page. It can be changed easily but I think most browser will block this behavior by default)
* It add a button for every sample no matter for the language.
* Because most samples are not strictly valid (often lacking the ```actor Main``` declaration they will not compile as they are, reducing the utility of this tool.