### PR TITLE
Fix multiply function definition formatting

### DIFF
--- a/types/primitives.md
+++ b/types/primitives.md
@@ -28,7 +28,7 @@ primitive BasicMath
   fun add(a: U64, b: U64) : U64 =>
     a + b
   
-  fun multiply(a : U64, b: U64) : U64 =>
+  fun multiply(a: U64, b: U64) : U64 =>
     a * b
 
 actor Main


### PR DESCRIPTION
This is an incredibly minor fix for a small formatting issue I notice while going through the tutorial.

`fun multiply(a : U64, b: U64) : U64` should be `fun multiply(a: U64, b: U64) : U64` instead so the formatting is consistent.