### PR TITLE
Fix formatting for function return types

### DIFF
--- a/types/primitives.md
+++ b/types/primitives.md
@@ -25,10 +25,10 @@ type DoorState is (OpenedDoor | ClosedDoor)
 
 // A collection of functions
 primitive BasicMath
-  fun add(a: U64, b: U64) : U64 =>
+  fun add(a: U64, b: U64): U64 =>
     a + b
   
-  fun multiply(a: U64, b: U64) : U64 =>
+  fun multiply(a: U64, b: U64): U64 =>
     a * b
 
 actor Main


### PR DESCRIPTION
This fixes the formatting issue mentioned here: https://github.com/ponylang/pony-tutorial/pull/248#issuecomment-343697691

Running `ag "\)\s+:\s*"` across the tutorial only showed these two results with incorrect formatting, so seems like this incorrect whitespace isn't an issue anywhere else.