### PR TITLE
Remove early reference to "error" in tail call example

### DIFF
--- a/expressions/methods.md
+++ b/expressions/methods.md
@@ -32,13 +32,15 @@ If you want to exit a function early then use the `return` command. If the funct
 Pony applies tail call optimization when applicable to allow a recursive implementation such as the following factorial function:
 
 ```pony
-fun factorial(x: I32): I32 ? =>
-  if x < 0 then error end
-  if x == 0 then
-    1
-  else
-    x * factorial(x - 1)?
-  end
+primitive Factorial
+  fun factorial(x: I32): I32 =>
+    if x < 0 then 
+      0
+    elseif x == 0 then
+      1
+    else
+      x * factorial(x - 1)
+    end
 ```
 The exact requirements to qualify for this optimization depends on the version of the LLVM compiler.
 


### PR DESCRIPTION
Closes #183