### PR TITLE
match.md: Fix examples for matches that don't compile.

### DIFF
--- a/pattern-matching/match.md
+++ b/pattern-matching/match.md
@@ -114,8 +114,6 @@ fun f(x: (U32 | String | None)): String =>
   | 3 => "three"
   | let u: U32 => "other integer"
   | let s: String => s
-  else
-    "something else"
   end
 ```
 
@@ -128,7 +126,7 @@ If you want to match on more than one operand at once then you can simply use a 
 ```pony
 fun f(x: (String | None), y: U32): String =>
   match (x, y)
-  | (None, let y: U32) => "none"
+  | (None, let u: U32) => "none"
   | (let s: String, 2) => s + " two"
   | (let s: String, 3) => s + " three"
   | (let s: String, let u: U32) => s + " other integer"


### PR DESCRIPTION
Two examples in match.md do not compile with the either 0.21.3 or the latest versions of ponyc.

The first example, an else, fails because the other matches are exhaustive and therefore else is unreachable.  This else branch is deleted in this patch.

The second example re-uses the variable named y.  This variable is renamed to u in this patch.