### PR TITLE
Grammar tweak

### DIFF
--- a/expressions/methods.md
+++ b/expressions/methods.md
@@ -238,6 +238,6 @@ They are presented more in-depth in the [Object Literals section](../expressions
 
 ## Privacy
 
-In Pony method names start either with a lower case letter or with an underscore followed by a lowercase letter. Methods with a leading underscore are private. This means they can only be called by code within the same package. Methods without a leading underscore are public and can be called by anyone.
+In Pony, method names start either with a lower case letter or with an underscore followed by a lowercase letter. Methods with a leading underscore are private. This means they can only be called by code within the same package. Methods without a leading underscore are public and can be called by anyone.
 
 __Can I start my method name with 2 (or more) underscores?__ No. If the first character is an underscore then the second one MUST be a lower case letter.


### PR DESCRIPTION
Add a comma to break up the sentence and clearly separate the two concepts being references, otherwise it reads like its a single concept.