### PR TITLE
Remove use of the word "insane" in divide-by-zero section

### DIFF
--- a/gotchas/divide-by-zero.md
+++ b/gotchas/divide-by-zero.md
@@ -12,7 +12,7 @@ In Pony, *integer division by zero results in zero*. That's right,
 let x = 1 / 0
 ```
 
-results in `0` being assigned to `x`. Insane right? Well, yes and no. From a mathematical standpoint, it is very much insane. From a practical standpoint, it is very much not.
+results in `0` being assigned to `x`. Baffling right? Well, yes and no. From a mathematical standpoint, it is very much baffling. From a practical standpoint, it is very much not.
 
 Similarly, *floating point division by zero results in `inf` or `-inf`*, depending on the sign of the numerator.
 


### PR DESCRIPTION
The divide by zero section of the tutorial used the word "insane" to
describe the fact that in Pony 1/0=0. Mental health advocates have
pointed out that words like "insane" and "crazy" stigmatize the
mentally ill. This change helps to foster an inclusive and welcoming
community.

Fixes #308