### PR TITLE
Clarify results of integer and floating point division by zero

### DIFF
--- a/gotchas/divide-by-zero.md
+++ b/gotchas/divide-by-zero.md
@@ -1,18 +1,20 @@
 # Divide by Zero
 
-What's 1 divided by 0? How about 10 divided by 0? What is the result you get in your favorite programming language? 
+What's 1 divided by 0? How about 10 divided by 0? What is the result you get in your favorite programming language?
 
 In math, divide by zero is undefined. There is no answer to that question as the expression 1/0 has no meaning. In many programming languages, the answer is a runtime exception that the user has to handle. In Pony, things are a bit different.
 
 ## Divide by zero in Pony
 
-In Pony, *divide by zero results in zero*. That's right,
+In Pony, *integer division by zero results in zero*. That's right,
 
 ```pony
 let x = 1 / 0
 ```
 
-results in `0` being assigned to `x`. Insane right? Well, yes and no. From a mathematical standpoint, it is very much insane. From a practical standpoint, it is very much not. 
+results in `0` being assigned to `x`. Insane right? Well, yes and no. From a mathematical standpoint, it is very much insane. From a practical standpoint, it is very much not.
+
+Similarly, *floating point division by zero results in `inf` or `-inf`*, depending on the sign of the numerator.
 
 ## Partial functions and math in Pony
 
@@ -29,4 +31,4 @@ We indicate that our function is partial via the `?` because we can't compute a 
 
 ## Death by a thousand `try`s
 
-From a practical perspective, having division as a partial function is awful. You end up with code littered with `try`s attempting to deal with the possibility of division by zero. Even if you had asserted that your denominator was not zero, you'd still need to protect against divide by zero because, at this time, the compiler can't detect that value dependent typing. So, as of right now (ponyc v0.2), divide by zero in Pony does not result in `error` but rather `0`. 
+From a practical perspective, having division as a partial function is awful. You end up with code littered with `try`s attempting to deal with the possibility of division by zero. Even if you had asserted that your denominator was not zero, you'd still need to protect against divide by zero because, at this time, the compiler can't detect that value dependent typing. So, as of right now (ponyc v0.2), divide by zero in Pony does not result in `error` but rather `0`.


### PR DESCRIPTION
The division by zero section is now more clear about the fact that
integer division by 0 is 0 and floating point division by zero is
`inf` or `-inf`. This well help developers understand what to expect
from division and make it clear that the results will differ depending
on whether the division is of integers or floats.

Closes #310