### PR TITLE
Fix broken links in divide-by-zero gotchas

### DIFF
--- a/content/gotchas/divide-by-zero.md
+++ b/content/gotchas/divide-by-zero.md
@@ -22,7 +22,7 @@ let x = I64(1) / I64(0)
 
 results in `0` being assigned to `x`. Baffling right? Well, yes and no. From a mathematical standpoint, it is very much baffling. From a practical standpoint, it is very much not.
 
-While Pony has [Partial division](/expressions/arithmetic.md#partial-and-checked-arithmetic):
+While Pony has [Partial division](/expressions/arithmetic#partial-and-checked-arithmetic):
 
 ```pony
 let x =
@@ -35,20 +35,20 @@ let x =
 
 Defining division as partial leads to code littered with `try`s attempting to deal with the possibility of division by zero. Even if you had asserted that your denominator was not zero, you'd still need to protect against divide by zero because, at this time, the compiler can't detect that value dependend typing.
 
-Pony also offers [Unsafe Division](/expressions/arithmetic.md#unsafe-arithmetic), which declares division by zero as undefined, as in C:
+Pony also offers [Unsafe Division](/expressions/arithmetic#unsafe-arithmetic), which declares division by zero as undefined, as in C:
 
 ```pony
 // the value of x is undefined
 let x = I64(1) /~ I64(0)
 ```
 
-But declaring this case as undefined does not help us out here. As a programmer you'd still need to guard that case in order to not poison your program with undefined values or risking terminating your program with a `SIGFPE`. So, in order to maintain a practical API and avoid undefined behaviour, _normal_ division on integers in Pony is defined to be `0`. To avoid `0`s silently creeping through your divisions, use [Partial or Checked Division](/expressions/arithmetic.md#partial-and-checked-arithmetic).
+But declaring this case as undefined does not help us out here. As a programmer you'd still need to guard that case in order to not poison your program with undefined values or risking terminating your program with a `SIGFPE`. So, in order to maintain a practical API and avoid undefined behaviour, _normal_ division on integers in Pony is defined to be `0`. To avoid `0`s silently creeping through your divisions, use [Partial or Checked Division](/expressions/arithmetic#partial-and-checked-arithmetic).
 
 ### Divide by zero on floating points
 
 In conformance with IEEE 754, *floating point division by zero results in `inf` or `-inf`*, depending on the sign of the numerator. 
 
-If you can assert that your denominator cannot be `0`, it is possible to use [Unsafe Division](/expressions/arithmetic.md#floating-point) to gain some performance:
+If you can assert that your denominator cannot be `0`, it is possible to use [Unsafe Division](/expressions/arithmetic#floating-point) to gain some performance:
 
 ```pony
 let x = F64(1.5) /~ F64(0.5)


### PR DESCRIPTION
Didn't get converted over when we moved from Gitbook to Hugo.

Closes #342