### PR TITLE
Remove unneeded reference capability in example

### DIFF
--- a/content/types/type-aliases.md
+++ b/content/types/type-aliases.md
@@ -49,7 +49,7 @@ primitive Colours
 You might also want to iterate over the enum like this to print its name for debugging purposes
 ```pony
 primitive ColourList
-  fun tag apply(): Array[Colour] =>
+  fun apply(): Array[Colour] =>
     [Red; Green; Blue]
 
 for colour in ColourList().values() do


### PR DESCRIPTION
It's not needed to understand the example and could be confusing.