### PR TITLE
Some clarifications in the Variables page.

### DIFF
--- a/content/expressions/variables.md
+++ b/content/expressions/variables.md
@@ -142,7 +142,9 @@ class Wombat
     name = name' // Error, can't assign to a let definition more than once
 ```
 
-__Can field declaration come after the constructor?__ No. To keep Pony's grammar unambiguous, only type aliases are allowed between an `actor Name`, `object is Trait`, etc. and a field definition. In any case, it's good style to make such variables easily visible to the programmer because fields are accessible from _any_ method of the type they're in.
+__Can field declarations appear after methods?__ No. If `var` or `let` keywords appear after a `fun` or `be` declaration, they will be treated as variables within the method body rather than fields within the type declaration. As a result, fields must appear prior to methods in the type declaration
+
+## Embedded Fields
 
 Unlike local variables, some types of fields can be declared using `embed`. Specifically, only classes or structs can be embedded - interfaces, traits, primitives and numeric types cannot. A field declared using `embed` is similar to one declared using `let`, but at the implementation level, the memory for the embedded class is laid out directly within the outer class. Contrast this with `let` or `var`, where the implementation uses pointers to reference the field class. Embedded fields can be passed to other functions in exactly the same way as `let` or `var` fields. Embedded fields must be initialised from a constructor expression.
 


### PR DESCRIPTION
This PR cleans up some messy/distracting text in the Variables page in favor of some more concise, clear language. It also better separates the section of the page talking about embedded fields.