### PR TITLE
Add strawman definition of  `digestof` to keywords.md

### DIFF
--- a/content/appendices/keywords.md
+++ b/content/appendices/keywords.md
@@ -21,7 +21,7 @@ This listing explains the usage of every Pony keyword.
 | compile_error | will provoke a compile error 
 | continue | continues a loop with the next iteration
 | consume | move a value to a new variable, leaving the original variable empty
-| digestof | create a `USize` value that represents the identity of the original value
+| digestof | create a `USize` value that summarizes the Pony object, similar to a Java object's `hashCode()` value.
 | do | loop statement, or after a with statement
 | else | conditional statement in if, for, while, repeat, try (as a catch block), match 
 | elseif | conditional statement, also used with ifdef

--- a/content/appendices/keywords.md
+++ b/content/appendices/keywords.md
@@ -21,6 +21,7 @@ This listing explains the usage of every Pony keyword.
 | compile_error | will provoke a compile error 
 | continue | continues a loop with the next iteration
 | consume | move a value to a new variable, leaving the original variable empty
+| digestof | create a `USize` value that represents the identity of the original value
 | do | loop statement, or after a with statement
 | else | conditional statement in if, for, while, repeat, try (as a catch block), match 
 | elseif | conditional statement, also used with ifdef


### PR DESCRIPTION
After looking through the stdlib code and trying to piece together what the LLVM code that implements `digestof` does, I've created an addition to `keywords.md` for a missing keyword, `digestof`.  I'm not sure that I'm correct, and I'm pretty sure that it's ugly.  Alternative definitions are welcome.