### PR TITLE
Reorder "Reference Capabilities" sections

### DIFF
--- a/content/reference-capabilities/capability-subtyping.md
+++ b/content/reference-capabilities/capability-subtyping.md
@@ -4,7 +4,7 @@ section: "Reference Capabilities"
 menu:
   toc:
     parent: "reference-capabilities"
-    weight: 90
+    weight: 80
 toc: true
 ---
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -4,7 +4,7 @@ section: "Reference Capabilities"
 menu:
   toc:
     parent: "reference-capabilities"
-    weight: 70
+    weight: 90
 toc: true
 ---
 

--- a/content/reference-capabilities/passing-and-sharing.md
+++ b/content/reference-capabilities/passing-and-sharing.md
@@ -4,7 +4,7 @@ section: "Reference Capabilities"
 menu:
   toc:
     parent: "reference-capabilities"
-    weight: 80
+    weight: 70
 toc: true
 ---
 


### PR DESCRIPTION
The "Combining Capabilities" section of the tutorial covers topics that are more advanced than the previous ones. Placing it after "Capability Subtyping" means that someone reading the tutorial could start writing toy programs that send simple messages to other actors, such as `String iso`, right after reading "Passing and Sharing References".