### PR TITLE
Fix typo in structs section: s/throughtout/throughout

### DIFF
--- a/content/types/structs.md
+++ b/content/types/structs.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-A `struct` is similiar to a `class`. There's a couple very important differences. You'll use classes throughtout your Pony code. You'll rarely use structs. We'll discuss structs in more depth in the [C-FFI chapter](/c-ffi.html) of the tutorial. In the meantime, here's a short introduction to the basics of structs.
+A `struct` is similiar to a `class`. There's a couple very important differences. You'll use classes throughout your Pony code. You'll rarely use structs. We'll discuss structs in more depth in the [C-FFI chapter](/c-ffi.html) of the tutorial. In the meantime, here's a short introduction to the basics of structs.
 
 ## Structs are "classes for FFI"
 


### PR DESCRIPTION
Hello! I was going through the tutorial and noticed this typo, so here is a PR fixing it. Thanks!