### PR TITLE
change type from I32 to USize in example to make it compile

### DIFF
--- a/content/expressions/arithmetic.md
+++ b/content/expressions/arithmetic.md
@@ -127,15 +127,15 @@ If overflow or division by zero are cases that need to be avoided and performanc
 // partial arithmetic
 let result =
   try
-    I32.max_value() +? env.args.size()
+    USize.max_value() +? env.args.size()
   else
     env.out.print("overflow detected")
   end
 
 // checked arithmetic
 let result =
-  match U64.max_value().addc(env.args.size())
-  | (let result: U64, false) =>
+  match USize.max_value().addc(env.args.size())
+  | (let result: USize, false) =>
     // use result
     ...
   | (_, true) =>


### PR DESCRIPTION
Found this while reading the documentation, I think that the focus was on how to intentionally get an overflow. With the provided example I was getting a compilation error:

```
argument not a subtype of parameter
          I32.max_value() +? env.args.size()
```

```
argument type is USize val
              I32.max_value() +? env.args.size()
```

```
parameter type is I32 val
      fun add_partial(y: I32): I32 ? =>
                               ^
```

```
USize val is not a subtype of I32 val
      fun size(): USize =>
                       ^
```
