### PR TITLE
fix hashable object literal, String.hash() is USize, hash64() should be used

### DIFF
--- a/content/expressions/methods.md
+++ b/content/expressions/methods.md
@@ -183,7 +183,7 @@ Default arguments can also be used in combination with positional and named argu
 
 ```pony
 class Foo
-  fun f(a:U32 = 1, b: U32 = 2, c: U32 = 3, d: U32 = 4, e: U32 = 5): U32  =>
+  fun f(a: U32 = 1, b: U32 = 2, c: U32 = 3, d: U32 = 4, e: U32 = 5): U32  =>
     0
 
   fun g() =>

--- a/content/expressions/object-literals.md
+++ b/content/expressions/object-literals.md
@@ -39,7 +39,7 @@ class Foo
     object is Hashable
       let s: String = str
       fun apply(): String => s
-      fun hash(): U64 => s.hash()
+      fun hash(): U64 => s.hash64()
     end
 ```
 

--- a/content/expressions/object-literals.md
+++ b/content/expressions/object-literals.md
@@ -53,7 +53,7 @@ class Foo
     object iso is Hashable
       let s: String = str
       fun apply(): String => s
-      fun hash(): U64 => s.hash()
+      fun hash(): U64 => s.hash64()
     end
 ```
 
@@ -64,7 +64,7 @@ class Foo
   fun foo(str: String): Hashable iso^ =>
     object iso is Hashable
       fun apply(): String => str
-      fun hash(): U64 => str.hash()
+      fun hash(): U64 => str.hash64()
     end
 ```
 

--- a/content/expressions/object-literals.md
+++ b/content/expressions/object-literals.md
@@ -27,19 +27,21 @@ Ok, that's pretty trivial. Let's extend it so that it explicitly provides an int
 ```pony
 object is Hashable
   fun apply(): String => "hi"
-  fun hash(): U64 => this().hash()
+  fun hash(): USize => this().hash()
 end
 ```
 
 What we can't do is specify constructors in an object literal, because the literal _is_ the constructor. So how do we assign to fields? Well, we just assign to them. For example:
 
 ```pony
+use "collections"
+
 class Foo
   fun foo(str: String): Hashable =>
     object is Hashable
       let s: String = str
       fun apply(): String => s
-      fun hash(): U64 => s.hash64()
+      fun hash(): USize => s.hash()
     end
 ```
 
@@ -48,23 +50,27 @@ When we assign to a field in the constructor, we are _capturing_ from the lexica
 An object literal with fields is returned as a `ref` by default unless an explicit reference capability is declared by specifying the capability after the `object` keyword. For example, an object with sendable captured references can be declared as `iso` if needed:
 
 ```pony
+use "collections"
+
 class Foo
   fun foo(str: String): Hashable iso^ =>
     object iso is Hashable
       let s: String = str
       fun apply(): String => s
-      fun hash(): U64 => s.hash64()
+      fun hash(): USize => s.hash()
     end
 ```
 
 We can also implicitly capture values from the lexical scope by using them in the object literal. Sometimes values that aren't local variables, aren't fields, and aren't parameters of a function are called _free variables_. By using them in a function, we are _closing over_ them - that is, capturing them. The code above could be written without the field `s`:
 
 ```pony
+use "collections"
+
 class Foo
   fun foo(str: String): Hashable iso^ =>
     object iso is Hashable
       fun apply(): String => str
-      fun hash(): U64 => str.hash64()
+      fun hash(): USize => str.hash()
     end
 ```
 


### PR DESCRIPTION
Based on the documentation, String.hash() is USize, not U64:
https://stdlib.ponylang.io/builtin-String/#hash
