### PR TITLE
Titlecasing for all subsections

### DIFF
--- a/content/appendices/error-messages.md
+++ b/content/appendices/error-messages.md
@@ -1,5 +1,5 @@
 ---
-title: "A short guide to Pony error messages"
+title: "A Short Guide to Pony Error Messages"
 section: "Appendices"
 menu:
   toc:

--- a/content/gotchas/side-effect-ordering-in-function-call-expressions.md
+++ b/content/gotchas/side-effect-ordering-in-function-call-expressions.md
@@ -1,5 +1,5 @@
 ---
-title: "Function call side effects"
+title: "Function Call Side Effects"
 section: "Gotchas"
 menu:
   toc:


### PR DESCRIPTION
Later in the tutorial some subsection headers are not titlecased. Note: There are also internal sections for individual entries that break this rule (see https://tutorial.ponylang.io/appendices/error-messages.html where the internal section have no capitals), but I only fixed the headers in the navigation. If we wish to apply this rule generally across all sections no matter there level I can certainly do this. There is also a configuration option to this effect for Hugo, see https://gohugo.io/getting-started/configuration/#configure-title-case but I am unsure where all the Hugo title macro is used currently.