### PR TITLE
Capitalize non-code mentions of Pony

### DIFF
--- a/content/appendices/memory-allocation.md
+++ b/content/appendices/memory-allocation.md
@@ -19,7 +19,7 @@ Pony is a null-free, type-safe language, with no dangling pointers, no buffer ov
 
 ## But Caveat Emptor
 
-But pony can be used to create **C libraries** and pony can use external C libraries via the **FFI** which does not have this luxury.
+But Pony can be used to create **C libraries** and Pony can use external C libraries via the **FFI** which does not have this luxury.
 
 So you **can** use any external C library out there, but the question is if you **need to** and if you **should**.
 

--- a/content/c-ffi/c-abi.md
+++ b/content/c-ffi/c-abi.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-The FFI support in pony uses the C application binary interface (ABI) to interface with native code. The C ABI is a calling convention, one of many, that allow objects from different programming languages to be used together.
+The FFI support in Pony uses the C application binary interface (ABI) to interface with native code. The C ABI is a calling convention, one of many, that allow objects from different programming languages to be used together.
 
 ## Writing a C library for Pony
 
@@ -17,7 +17,7 @@ Writing your own C library for use by Pony is almost as easy as using existing l
 Let's look at a complete example of a C function we may wish to provide to Pony. A Jump Consistent Hash, for example, could be provided in pure Pony as follows:
 
 ```pony
-// Jump consistent hashing in pony, with an inline pseudo random generator
+// Jump consistent hashing in Pony, with an inline pseudo random generator
 
 fun jch(key: U64, buckets: I64): I32 =>
   var k = key
@@ -94,7 +94,7 @@ The Pony code to use this new C library is just like the code we've already seen
 
 ```pony
 """ 
-This is an example of pony integrating with native code via the built-in FFI
+This is an example of Pony integrating with native code via the built-in FFI
 support
 """
 
@@ -119,4 +119,4 @@ actor Main
     end
 ```
 
-We can now use ponyc to compile a native executable integrating pony and our C library. And that's all we need to do.
+We can now use ponyc to compile a native executable integrating Pony and our C library. And that's all we need to do.

--- a/content/expressions/literals.md
+++ b/content/expressions/literals.md
@@ -147,7 +147,7 @@ let triple_quoted_string_docs =
   Triple quoted strings are the way to go for long multiline text.
   They are extensively used as docstrings which are turned into api documentation.
 
-  They get some special treatment, in order to keep pony code readable:
+  They get some special treatment, in order to keep Pony code readable:
 
   * The string literal starts on the line after the opening triple quote.
   * Common indentation is removed from the string literal


### PR DESCRIPTION
As Pony is the name of the language, any plaintext/non-code mentions of it should have the name capitalized.

Note that the String Literals that mention `pony` as a variable name have not been changed as these were the only code mentions of pony