### PR TITLE
Resolve #336; is/isnt keywords use for identity comparison

### DIFF
--- a/content/appendices/keywords.md
+++ b/content/appendices/keywords.md
@@ -37,6 +37,8 @@ This listing explains the usage of every Pony keyword.
 | interface | used in structural subtyping
 | is | (1) used in nominal subtyping
 |    | (2) in type aliasing
+|    | (3) identity comparison
+| isnt | negative identity comparison
 | iso | reference capability – read and write uniqueness
 | lambda | to make a closure
 | let | declaration of immutable variable: you can't rebind this name to a new value


### PR DESCRIPTION
Added third use of `is` keyword for identity comparison and `isnt` entry as negative identity comparison in keyword table.