### PR TITLE
Clarifying when a lambda requires a `ref` reference capability

### DIFF
--- a/content/expressions/object-literals.md
+++ b/content/expressions/object-literals.md
@@ -147,7 +147,7 @@ actor Main
 
 The `reduce` method in this example requires the lambda type for the `f` parameter to require a reference capability of `val`. The lambda object passed in as an argument does not need to declare an explicit reference capability because `val` is the default for a lambda that does not capture anything.
 
-As mentioned previously the lambda desugars to an object literal with an `apply` method. The reference capability for the `apply` method defaults to `box` like any other method. In a lambda that captures this needs to be `ref` if the function needs to modify any of the captured variables or call `ref` methods on them. The reference capability for the method (versus the reference capability for the object which was described above) is defined by putting the capability before the parenthesized argument list.
+As mentioned previously the lambda desugars to an object literal with an `apply` method. The reference capability for the `apply` method defaults to `box` like any other method. In a lambda that captures references, this needs to be `ref` if the function needs to modify any of the captured variables or call `ref` methods on them. The reference capability for the method (versus the reference capability for the object which was described above) is defined by putting the capability before the parenthesized argument list.
 
 ```pony
 use "collections"


### PR DESCRIPTION
A sentence in the paragraph that explains when a lambda requires `ref` reads awkwardly. The biggest problem is that it appears to be missing a comma:

> In a lambda that **captures references, this needs** to be `ref` if the function needs to modify any of the captured variables or call `ref` methods on them.