### PR TITLE
Combining capabilities: Rework the "see its own fields" wording of viewpoint adaptation.

### DIFF
--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -14,9 +14,9 @@ This is because all the guarantees that the __origin__ reference capability make
 
 # Viewpoint adaptation
 
-The process of combining origin and field capabilities is called __viewpoint adaptation__. That is, the __origin__ has a __viewpoint__, and can "see" its fields only from that __viewpoint__.
+The process of combining origin and field capabilities is called __viewpoint adaptation__. That is, the __origin__ has a __viewpoint__, and its fields can be "seen" only from that __viewpoint__.
 
-Let's start with a table. This shows how __fields__ of each capability "look" to __origins__ of each capability.
+Let's start with a table. This shows how __fields__ of each capability look to __origins__ of each capability.
 
 ---
 


### PR DESCRIPTION
Explanation below:

While it is true that access to receivers and fields will follow
this, in that `this` is just a normal variable, I feel this outlook
could be confusing when understood with receiver recovery, and
changing of capabilities.

A reader might conclude or speculate that a variable with type iso,
can only see its own contents with those viewpoints, but the notion
of an object accessing itself is most closely aligned with calling
a function (or behavior). Since this will almost certainly be
`fun ref` and `fun box`, the reader may become confused by
reading it as though it would apply to those functions on `iso`
variables.

I'm not implying that it would be sensible to conclude that, but
that a reader may get confused that that would seem to be implied.