### PR TITLE
Describe capabilities of fields before discussing viewpoint adaptation

### DIFF
--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) chapter, we skimmed over a rather important detail, by only using defaults. Fields, just like variables, have their own capabilities! A field in the class has to make all the same guarantees as a variable. An `iso` field for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
+When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A field in the class has to make all the same guarantees as a variable. An `iso` field for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
 
 Once we have fields with capabilities inside objects with capabilities, now we've got two capabilities to keep track of. Of course, if you've read the title of this chapter, you might suspect that there's a way to combine them, and you'd be right.
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A field in a class has to make the exact same guarantees. An `iso` field, for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
+When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A `val` field still refers to something permanently immutable. An `iso` field is still globally unique: it can only be accessed except through this field of a single instance.
 
 Once we have fields with capabilities inside objects with capabilities, now we have two capabilities to keep track of.  When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for the capability of the __field__.
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -10,13 +10,13 @@ toc: true
 
 When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A field in a class has to make the exact same guarantees. An `iso` field, for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
 
-Once we have fields with capabilities inside objects with capabilities, now we have two capabilities to keep track of.  When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for its __fields__.
+Once we have fields with capabilities inside objects with capabilities, now we have two capabilities to keep track of.  When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for the capability of the __field__.
 
 # Viewpoint adaptation
 
 The process of combining origin and field capabilities is called __viewpoint adaptation__. That is, the __origin__ has a __viewpoint__, and its fields can be "seen" only from that __viewpoint__.
 
-Let's start with a table. This shows how __fields__ of each capability look when using __origins__ of each capability.
+Let's start with a table. This shows how a __field__ of each capability looks when using an __origin__ of each capability.
 
 ---
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -8,9 +8,11 @@ menu:
 toc: true
 ---
 
-When a field of an object is read, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the field is being read from.
+When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) chapter, we skimmed over a rather important detail, by only using defaults. Fields, just like variables, have their own capabilities! A field in the class has to make all the same guarantees as a variable. An `iso` field for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
 
-This is because all the guarantees that the __origin__ reference capability makes have to be maintained for its fields as well.
+Once we have fields with capabilities inside objects with capabilities, now we've got two capabilities to keep track of. Of course, if you've read the title of this chapter, you might suspect that there's a way to combine them, and you'd be right.
+
+When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the field is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for its fields.
 
 # Viewpoint adaptation
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A `val` field still refers to something permanently immutable. An `iso` field is still globally unique: it can only be accessed except through this field of a single instance.
+When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A `val` field still refers to something permanently immutable, a `tag` field still can't be read from. An `iso` field is still globally unique: it can only be accessed except through this field of a single instance.
 
 Once we have fields with capabilities inside objects with capabilities, now we have two capabilities to keep track of.  When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for the capability of the __field__.
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -10,9 +10,7 @@ toc: true
 
 When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A field in a class has to make the exact same guarantees. An `iso` field, for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
 
-Once we have fields with capabilities inside objects with capabilities, now we've got two capabilities to keep track of. Of course, if you've read the title of this chapter, you might suspect that there's a way to combine them, and you'd be right.
-
-When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for its __fields__.
+Once we have fields with capabilities inside objects with capabilities, now we have two capabilities to keep track of.  When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for its __fields__.
 
 # Viewpoint adaptation
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -12,7 +12,7 @@ When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) 
 
 Once we have fields with capabilities inside objects with capabilities, now we've got two capabilities to keep track of. Of course, if you've read the title of this chapter, you might suspect that there's a way to combine them, and you'd be right.
 
-When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the field is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for its fields.
+When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for its __fields__.
 
 # Viewpoint adaptation
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -18,7 +18,7 @@ When a field of an object is accessed or extracted, its reference capability dep
 
 The process of combining origin and field capabilities is called __viewpoint adaptation__. That is, the __origin__ has a __viewpoint__, and its fields can be "seen" only from that __viewpoint__.
 
-Let's start with a table. This shows how __fields__ of each capability look to __origins__ of each capability.
+Let's start with a table. This shows how __fields__ of each capability look when using __origins__ of each capability.
 
 ---
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A `val` field still refers to something permanently immutable, a `tag` field still can't be read from. An `iso` field is still globally unique: it can only be accessed except through this field of a single instance.
+When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A `val` field still refers to something permanently immutable. A `tag` field still can't be read from. An `iso` field is still globally unique: it can only be accessed except through this field of a single instance.
 
 Once we have fields with capabilities inside objects with capabilities, now we have two capabilities to keep track of.  When a field of an object is accessed or extracted, its reference capability depends both on the reference capability of the field and the reference capability of the __origin__, that is, the object the __field__ is being read from. We have to pick a capability for the combination that maintains the guarantees for both the __origin__ reference capability, and for the capability of the __field__.
 

--- a/content/reference-capabilities/combining-capabilities.md
+++ b/content/reference-capabilities/combining-capabilities.md
@@ -8,7 +8,7 @@ menu:
 toc: true
 ---
 
-When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A field in the class has to make all the same guarantees as a variable. An `iso` field for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
+When we talked about fields in the [classes]({{< relref "types/classes.md" >}}) and [variables]({{< relref "expressions/variables.md" >}}) chapters, we passed over the detail of field capabilities. Fields, just like variables, have their own capabilities! A field in a class has to make the exact same guarantees. An `iso` field, for instance, is globally unique. The only way to reference it is through this single field of the object (except of course, `tag` references, or shared `val` portions).
 
 Once we have fields with capabilities inside objects with capabilities, now we've got two capabilities to keep track of. Of course, if you've read the title of this chapter, you might suspect that there's a way to combine them, and you'd be right.
 


### PR DESCRIPTION
This is a simultaneous issue I had when starting and a proposed fix with the knowledge I have now.

When first reading this, the section on viewpoints and fields was rather confusing, since it didn't feel clear what it *meant* to have a capability of a field (and we never actually mentioned them in the classes chapter). This introduces them, and makes sure to specify that a field makes the same exact global guarantees.