### PR TITLE
Add details to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,21 @@
 # Pony Tutorial
 
-Hi there! This is the source for the Pony tutorial.
+Accompanying language tutorial for Pony -- an open-source, object-oriented, actor-model, capabilities-secure, high-performance programming language.
+
+## Status
+
+The Pony Tutorial is still in-progress. It covers many of the ideas and functionality of Pony, however there remain elements of the language not adequately explained in the Pony Tutorial.
+
+## Contributing
+
+We welcome contributions to the Pony Tutorial. Before contributing, please read through [CONTRIBUTING.md](CONTRIBUTING.md).
+
+If you are looking for a way to contribute, check out the [Good First Issues](https://github.com/ponylang/pony-tutorial/issues?q=is:issue+is:open+label:%22good+first+issue%22).
+
+## Discussion
+
+If you would like to discuss changes to the Pony Tutorial or topics which need further clarification, please open a new topic on our community Zulip in the [**#tutorial**](https://ponylang.zulipchat.com/#narrow/stream/tutorial) stream.
+
+## License
+
+All content in the Pony Tutorial is covered by the terms presented in [LICENSE](LICENSE).


### PR DESCRIPTION
I happened to have navigated to the Tutorial via GitHub UI this week and noticed the README was rather blank. I added details for summary, status, contributing, discussion, and license. 

There is a problem that the number of  "good first issues" is currently none so if this is merged I will review the issues and relabel. We have a "help wanted" label which is partially being used as a stand-in for "good first issues" so my definition of "good first issue" will be any issue which could be reasonably handled by someone who has read through the tutorial once. Therefore any additions of undocumented features are not "good first issues" while changes for clarity, approachability, and/or (additional) examples are reasonable.