### PR TITLE
Fix some typos

### DIFF
--- a/content/appendices/annotations.md
+++ b/content/appendices/annotations.md
@@ -56,7 +56,7 @@ The following annotations are recognised by the Pony compiler. Note that the Pon
 
 #### `packed`
 
-Recognised on a a `struct` declaration. Removes padding in the associated `struct`, making it ABI-compatible with a packed C structure with compatible members (declared with the `__attribute__((packed))` extension or the `#pragma pack` preprocessor directive in many C compilers).
+Recognised on a `struct` declaration. Removes padding in the associated `struct`, making it ABI-compatible with a packed C structure with compatible members (declared with the `__attribute__((packed))` extension or the `#pragma pack` preprocessor directive in many C compilers).
 
 ```pony
 struct \packed\ MyPackedStruct

--- a/content/expressions/arithmetic.md
+++ b/content/expressions/arithmetic.md
@@ -166,7 +166,7 @@ mulc()         | Checked multiplication, second tuple element is `true` on overf
 divc()         | Checked division, second tuple element is `true` on overflow or division by zero.
 remc()         | Checked remainder, second tuple element is `true` on overflow or division by zero.
 modc()         | Checked modulo, second tuple element is `true` on overflow or division by zero.
-fldc()         | Checked floored division, second typle element is `true` on overflow or division by zero.
+fldc()         | Checked floored division, second tuple element is `true` on overflow or division by zero.
 
 ---
 

--- a/content/gotchas/divide-by-zero.md
+++ b/content/gotchas/divide-by-zero.md
@@ -33,7 +33,7 @@ let x =
   end
 ```
 
-Defining division as partial leads to code littered with `try`s attempting to deal with the possibility of division by zero. Even if you had asserted that your denominator was not zero, you'd still need to protect against divide by zero because, at this time, the compiler can't detect that value dependend typing.
+Defining division as partial leads to code littered with `try`s attempting to deal with the possibility of division by zero. Even if you had asserted that your denominator was not zero, you'd still need to protect against divide by zero because, at this time, the compiler can't detect that value dependent typing.
 
 Pony also offers [Unsafe Division]({{< relref "expressions/arithmetic.md#unsafe-arithmetic" >}}), which declares division by zero as undefined, as in C:
 

--- a/content/reference-capabilities/capability-matrix.md
+++ b/content/reference-capabilities/capability-matrix.md
@@ -43,7 +43,7 @@ __Don't deny any local aliases__ | `ref` | `box` | __`tag`__
 
 In the context of the matrix, "denying a capability" means that any other alias to that reference is not allowed to do that action. For example, since `trn` denies other local write aliases (but allows reads), this is the only reference that allows writing to the object; and since it denies both read and write aliases to other actors, it's safe to write inside this actor, thus being mutable. And since `box` does not break any guarantees that `trn` makes (local reads are allowed, but global writes are forbidden), we can create `box` aliases to a `trn` reference.
 
-You'll notice that the top-right side is empty. That's because, as previously discussed, we cannot make any local guarantees that are more restrictive than the global guarantees, or we'd end up with invalid capabilities that could be written to in this actor but read somewehre else at the same time.
+You'll notice that the top-right side is empty. That's because, as previously discussed, we cannot make any local guarantees that are more restrictive than the global guarantees, or we'd end up with invalid capabilities that could be written to in this actor but read somewhere else at the same time.
 
 The matrix also helps visualizing other concepts previously discussed in this chapter:
 


### PR DESCRIPTION
1. `content/appendices/annotations.md` (line 59): a a `struct` -> a `struct`
2. `content/expressions/arithmetic.md` (line 169): typle -> tuple
3. `content/gotchas/divide-by-zero.md` (line 36): dependend -> dependent
4. `content/reference-capabilities/capability-matrix.md` (line 46): somewehre -> somewhere