### PR TITLE
Correct type of x in example

### DIFF
--- a/content/expressions/control-structures.md
+++ b/content/expressions/control-structures.md
@@ -125,16 +125,13 @@ This will give __x__ the value "Sarah" as it is the last name in our list. If ou
 ```pony
 actor Main
   new create(env: Env) =>
-    var x: (String | None) =
+    var x: String =
       for name in Array[String].values() do
         name
       else
         "no names!"
       end
-    match x
-    | let s: String => env.out.print("x is " + s)
-    | None => env.out.print("x is None")
-    end
+    env.out.print("x is " + x)
 ```
 
 Here the value of __x__ is "no names!"


### PR DESCRIPTION
The example of loop iteration with an "else" branch that is also a `String` now correctly specifies the type of `x` as `String`. The following `match` statement is thereby obsolete.