### PR TITLE
Re-enable htmlproofer

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -28,6 +28,8 @@ markdown_extensions:
 plugins:
   - search
   - ezlinks
+  - htmlproofer:
+      raise_error: True
 
 theme:
   name: material

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -30,6 +30,7 @@ plugins:
   - ezlinks
   - htmlproofer:
       raise_error: True
+      raise_error_excludes: [429, "https://github.com/"]
 
 theme:
   name: material


### PR DESCRIPTION
Re-enabling this locally produced the following error so I am looking to see if there are any issues with building on Netlify.

```error
ERROR   -  Error building page 'expressions/variables.md': https://github.com/ponylang/pony-tutorial/: 429
```