### PR TITLE
Remove net/ssl package from safe example

### DIFF
--- a/docs/object-capabilities/trust-boundary.md
+++ b/docs/object-capabilities/trust-boundary.md
@@ -17,7 +17,7 @@ But we can do better than that.
 In Pony, you can optionally declare a set of _safe_ packages on the `ponyc` command line, like this:
 
 ```sh
-ponyc --safe=files:net:net/ssl my_project
+ponyc --safe=files:net:process my_project
 ```
 
-Here, we are declaring that only the `files`, `net` and `net/ssl` packages are allowed to use C-FFI calls. We've established our trust boundary: any other packages that try to use C-FFI calls will result in a compile-time error.
+Here, we are declaring that only the `files`, `net` and `process` packages are allowed to use C-FFI calls. We've established our trust boundary: any other packages that try to use C-FFI calls will result in a compile-time error.


### PR DESCRIPTION
The net/ssl package was extracted into its own independent library.