### PR TITLE
Improve FFI documentation

### DIFF
--- a/docs/appendices/examples.md
+++ b/docs/appendices/examples.md
@@ -35,32 +35,6 @@ for colour in ColourList().values() do
 end
 ```
 
-## Read struct values from FFI
-
-If you have a C struct which returns a struct with data like this
-
-```c
-typedef struct {
-  uint8_t code;
-  float x;
-  float y;
-} EGLEvent;
-
-EGLEvent getEvent() {
-    EGLEvent e = {1, ev.xconfigure.width, ev.xconfigure.height};
-    return e;
-}
-
-```
-
-then you can destructure it and get the values using a tuple
-
-```pony
-use @getEvent[EGLEvent]()
-type EGLEvent is (U8, F32, F32)
-(var code, var x, var y) = @getEvent()
-```
-
 ## Pass an Array of values to FFI (TODO)
 
 ```pony

--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -36,19 +36,21 @@ An FFI signature is public to all Pony files inside the same package, so you onl
 
 Many C functions require types that don't have an exact equivalent in Pony. A variety of features is provided for these.
 
-For FFI functions that have no return value (ie they return `void` in C) the return value specified should be `[None]`.
+For FFI functions that have no return value (i.e. they return `void` in C) the return value specified should be `None`.
 
-In Pony String is an object with a header and fields, but in C a `char*` is simply a pointer to character data. The `.cstring()` function on String provides us with a valid pointer to hand to C. Our `fwrite` example above makes use of this for the first argument.
+In Pony, a String is an object with a header and fields, while in C a `char*` is simply a pointer to character data. The `.cstring()` function on String provides us with a valid pointer to hand to C. Our `mkdir` example above makes use of this for the first argument.
 
-Pony classes correspond directly to pointers to the class in C.
+Pony classes and structs correspond directly to pointers to the class or struct in C.
 
 For C pointers to simple types, such as U64, the Pony `Pointer[]` polymorphic type should be used, with a `tag` reference capability. `Pointer[U8] tag` should be used for void*.
 
-To pass pointers to values to C the `addressof` operator can be used (previously `&`), just like taking an address in C. This is done in the standard library to pass the address of a `U64` to an FFI function that takes a `uint64_t*` as an out parameter:
+To pass pointers to values to C the `addressof` operator can be used (previously `&`), just like taking an address in C. This is done in the standard library to pass the address of a `U32` to an FFI function that takes a `int*` as an out parameter:
 
 ```pony
-var len = U64(0)
-@pcre2_substring_length_bynumber_8[I32](_match, i.u32(), addressof len)
+use @frexp[F64](value: F64, exponent: Pointer[U32])
+// ...
+var exponent: U32 = 0
+var mantissa = @frexp(this, addressof exponent)
 ```
 
 ### Get and Pass Pointers to FFI

--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -28,6 +28,8 @@ FFI functions have the @ symbol before its name, and FFI signatures are declared
 
 The use @ command can take a condition just like other `use` commands. This is useful in this case, since the `_mkdir` function only exists in Windows.
 
+If the name of the C function that you want to call is also a [reserved keyword in Pony](/appendices/keywords.md) (such as `box`), you will need to wrap the name in double quotes (`@"box"`). If you forget to do so, your program will not compile.
+
 An FFI signature is public to all Pony files inside the same package, so you only need to write them once.
 
 ## C types

--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -71,7 +71,7 @@ var mantissa = @frexp(this, addressof exponent)
 
 ### Get and Pass Pointers to FFI
 
-To pass and receive pointers to c structs you need to declare pointer to primitives
+If you want to receive a pointer to an opaque C type, using a pointer to a primitive can be useful:
 
 ```pony
 use @XOpenDisplay[Pointer[_XDisplayHandle]](name: Pointer[U8] tag)
@@ -90,6 +90,8 @@ if e_dpy.is_null() then
   env.out.print("eglGetDisplay failed")
 end
 ```
+
+The above example would also work if we used `Pointer[None]` for all the pointer types. By using a pointer to a primitive, we are adding a level of type safety, as the compiler will ensure that we don't pass a pointer to any other type as a parameter to `eglGetDisplay`. It is important to note that these primitives should __not be used anywhere except as a type parameter__ of `Pointer[]`, to avoid misuse.
 
 ### Read Struct Values from FFI
 

--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -95,9 +95,11 @@ The above example would also work if we used `Pointer[None]` for all the pointer
 
 ### Read Struct Values from FFI
 
-A common pattern in C is to pass a struct pointer to a function, and that function will fill in various values in the struct. To do this in Pony, you make a `struct` and then use a `NullablePointer`:
+A common pattern in C is to pass a struct pointer to a function, and that function will fill in various values in the struct. To do this in Pony, you make a `struct` and then use a `NullablePointer`, which denotes a possibly-null type:
 
 ```pony
+use @ioctl[I32](fd: I32, req: U32, ...)
+
 struct Winsize
   var height: U16 = 0
   var width: U16 = 0
@@ -110,6 +112,8 @@ let size = Winsize
 
 env.out.print(size.height.string())
 ```
+
+A `NullablePointer` type can only be used with `structs`, and is only intended for output parameters (like in the example above) or for return types from C. You don't need to use a `NullablePointer` if you are only passing a `struct` as a regular input parameter.
 
 ### Variadic C functions
 

--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -129,6 +129,8 @@ var iov = (data.cpointer(), data.size())
 
 In the example above, the type `Pointer[(Pointer[U8] tag, USize)] tag` is equivalent to the `IOVec` struct type we defined earlier. That is, _a struct type is equivalent to a pointer to a tuple type with the fields of the struct as elements, in the same order as the original struct type defined them_.
 
+**Can I pass struct types by value, instead of passing a pointer?** Not at the moment. This is a known limitation of the current FFI system, but it is something the Pony team is interested in fixing.
+
 ### Working with Structs: from C to Pony
 
 A common pattern in C is to pass a struct pointer to a function, and that function will fill in various values in the struct. To do this in Pony, you make a `struct` and then use a `NullablePointer`, which denotes a possibly-null type:


### PR DESCRIPTION
This is a general stab at making the FFI docs better / clarifying some details. Hopefully the commit messages clarify individual changes.

Fixes #263, #303 and #466.
Resolves some of the points raised in #82, but maybe it should be kept open as a "catch-all" FFI docs improvement issue.

And I think #332 is also fixed by this, by clarifying that structs are equivalent to pointer to structs from the C point of view.