### PR TITLE
The mandatory FFI "use" change improves our safety story.

### DIFF
--- a/docs/types/at-a-glance.md
+++ b/docs/types/at-a-glance.md
@@ -35,4 +35,4 @@ The Pony type system offers a lot of guarantees, even more than other statically
 
 Some of those will make sense right now. Some of them may not mean much to you yet (like capabilities-security and causal messaging), but we'll get to those concepts later on.
 
-__If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony's type system guarantees only apply to code written in Pony. Code written in other languages gets only the guarantees provided by that language.
+__If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony has no way of determining if the FFI definition you provide is in the format your FFI library expects. Pony's type system does guarantee that data passed to your FFI calls match those type definitions you provide. This additional safety is not a guarantee. Pony's type system can only guarantee code written in Pony. Code written in other languages gets only the guarantees provided by that language.

--- a/docs/types/at-a-glance.md
+++ b/docs/types/at-a-glance.md
@@ -39,4 +39,4 @@ __If I use Pony's FFI to call code written in another language, does Pony magica
 
 Pony requires FFI parameters to be explicitly defined as Pony types in advance. This allows the typechecker to guarantee that no code-paths exist that would result in an FFI call that violated the top-level definition. This assurance is not available in many other languages.
 
-Unfortunately, As there is no way Pony can validate compatibility between your top-level definition and what the library expects Pony's guarantees cannot be extended.
+Unfortunately, as there is no way Pony can validate compatibility between your top-level definition and what the library expects, Pony's guarantees cannot be extended.

--- a/docs/types/at-a-glance.md
+++ b/docs/types/at-a-glance.md
@@ -37,7 +37,6 @@ Some of those will make sense right now. Some of them may not mean much to you y
 
 __If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony's type system can only guarantee code written in Pony. Code written in other languages gets only the guarantees provided by that language.
 
-Pony requires FFI parameters be explicitly defined as Pony types in advance. This allows the typechecker to guarantee that no code-paths exist that would result in an FFI call that violated the top-level definition. This assurance is not available in many other languages.
+Pony requires FFI parameters to be explicitly defined as Pony types in advance. This allows the typechecker to guarantee that no code-paths exist that would result in an FFI call that violated the top-level definition. This assurance is not available in many other languages.
 
 Unfortunately, As there is no way Pony can validate compatibility between your top-level definition and what the library expects Pony's guarantees cannot be extended.
-

--- a/docs/types/at-a-glance.md
+++ b/docs/types/at-a-glance.md
@@ -35,8 +35,9 @@ The Pony type system offers a lot of guarantees, even more than other statically
 
 Some of those will make sense right now. Some of them may not mean much to you yet (like capabilities-security and causal messaging), but we'll get to those concepts later on.
 
-__If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony's type system can only guarantee code written in Pony. Code written in other languages gets only the guarantees provided by that language.
+__If I use Pony's FFI to call code written in another language, does Pony make the same guarantees for the code I call?__ Sadly, no. Pony's type system can only guarantee code written in Pony. Code written in other languages get only the guarantees provided by that language.
 
-Pony requires FFI parameters to be explicitly defined as Pony types in advance. The type system guarantees at compile-time that no code-paths exist that violate the definitions you provide on the Pony side of the FFI Interface.
+Pony requires FFI parameters to be explicitly declared as Pony types in advance. The type system provides a guarantee at compile-time that no code-paths exist that violate the definitions you provided on the Pony side of your FFI call.
 
-Unfortunately, Pony can't extend this guarantee to include the execution of external functions as it cannot possibly know if the code on the other side of the FFI Interface will break any of Pony's guarantees.
+This guarantee cannot be inclusive of foreign code as the compiler has no way to verify that it won't violate Pony's type system guarantees at runtime.
+

--- a/docs/types/at-a-glance.md
+++ b/docs/types/at-a-glance.md
@@ -37,6 +37,6 @@ Some of those will make sense right now. Some of them may not mean much to you y
 
 __If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony's type system can only guarantee code written in Pony. Code written in other languages gets only the guarantees provided by that language.
 
-Pony requires FFI parameters to be explicitly defined as Pony types in advance. This allows the typechecker to guarantee that no code-paths exist that would result in an FFI call that violated the top-level definition. This assurance is not available in many other languages.
+Pony requires FFI parameters to be explicitly defined as Pony types in advance. The type system guarantees at compile-time that no code-paths exist that violate the definitions you provide on the Pony side of the FFI Interface.
 
-Unfortunately, as there is no way Pony can validate compatibility between your top-level definition and what the library expects, Pony's guarantees cannot be extended.
+Unfortunately, Pony can't extend this guarantee to include the execution of external functions as it cannot possibly know if the code on the other side of the FFI Interface will break any of Pony's guarantees.

--- a/docs/types/at-a-glance.md
+++ b/docs/types/at-a-glance.md
@@ -35,4 +35,9 @@ The Pony type system offers a lot of guarantees, even more than other statically
 
 Some of those will make sense right now. Some of them may not mean much to you yet (like capabilities-security and causal messaging), but we'll get to those concepts later on.
 
-__If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony has no way of determining if the FFI definition you provide is in the format your FFI library expects. Pony's type system does guarantee that data passed to your FFI calls match those type definitions you provide. This additional safety is not a guarantee. Pony's type system can only guarantee code written in Pony. Code written in other languages gets only the guarantees provided by that language.
+__If I use Pony's FFI to call code written in another language, does Pony magically make the same guarantees for the code I call?__ Sadly, no. Pony's type system can only guarantee code written in Pony. Code written in other languages gets only the guarantees provided by that language.
+
+Pony requires FFI parameters be explicitly defined as Pony types in advance. This allows the typechecker to guarantee that no code-paths exist that would result in an FFI call that violated the top-level definition. This assurance is not available in many other languages.
+
+Unfortunately, As there is no way Pony can validate compatibility between your top-level definition and what the library expects Pony's guarantees cannot be extended.
+


### PR DESCRIPTION
Even though it is true that we can't make guarantees around FFI calls, the pony type system coupled with the now mandatory "use" statements does provide all the tools a programmer needs to guarantee that the data that they pass into their FFI functions is correct.

(Where "correct" is left as an exercise to the reader as they are the ones that need to strictly define what is "correct".  We can't automatically validate either the "shape" of the data or derive who manages the memory).

The point being, if they correctly describe the data using pony types, the pony compiler *will* enforce the shape of that data for them consistently throughout their application.  That is *huge*.

(How to map pony-types and build type-systems that are flexible _and_ safe is 95% of the difficulty of doing C-FFI)