### PR TITLE
Fixed words not highlighted/embed and one typo in chapter "reference-capabilities"

### DIFF
--- a/docs/.lide_workspace.lua
+++ b/docs/.lide_workspace.lua
@@ -1,1 +1,0 @@
-return {["views"]={[1]={["selection"]={[1]=108,[2]=223,[3]=108,[4]=223},["type"]="doc",["scroll"]={["y"]=1888,["x"]=901.6},["text"]=false,["filename"]="reference-capabilities/reference-capabilities.md",["active"]=true}},["type"]="leaf",["active_view"]=1}

--- a/docs/.lide_workspace.lua
+++ b/docs/.lide_workspace.lua
@@ -1,0 +1,1 @@
+return {["views"]={[1]={["selection"]={[1]=108,[2]=223,[3]=108,[4]=223},["type"]="doc",["scroll"]={["y"]=1888,["x"]=901.6},["text"]=false,["filename"]="reference-capabilities/reference-capabilities.md",["active"]=true}},["type"]="leaf",["active_view"]=1}

--- a/docs/reference-capabilities/combining-capabilities.md
+++ b/docs/reference-capabilities/combining-capabilities.md
@@ -12,13 +12,13 @@ Let's start with a table. This shows how a __field__ of each capability looks wh
 
 ---
 
-| &#x25B7;       | `iso` field | `trn` field | `ref` field | `val` field | `box` field | tag field |
+| &#x25B7;       | `iso` field | `trn` field | `ref` field | `val` field | `box` field | `tag` field |
 | -------------- | --------- | --------- | --------- | --------- | --------- | --------- |
-| __`iso` origin__ | `iso`       | `tag`       | `tag`       | `val`       | `tag`       | tag       |
-| __`trn` origin__ | `iso`       | `box`       | `box`       | `val`       | `box`       | tag       |
-| __`ref` origin__ | `iso`       | `trn`       | `ref`       | `val`       | `box`       | tag       |
-| __`val` origin__ | `val`       | `val`       | `val`       | `val`       | `val`       | tag       |
-| __`box` origin__ | `tag`       | `box`       | `box`       | `val`       | `box`       | tag       |
+| __`iso` origin__ | `iso`       | `tag`       | `tag`       | `val`       | `tag`       | `tag`       |
+| __`trn` origin__ | `iso`       | `box`       | `box`       | `val`       | `box`       | `tag`       |
+| __`ref` origin__ | `iso`       | `trn`       | `ref`       | `val`       | `box`       | `tag`       |
+| __`val` origin__ | `val`       | `val`       | `val`       | `val`       | `val`       | `tag`       |
+| __`box` origin__ | `tag`       | `box`       | `box`       | `val`       | `box`       | `tag`       |
 | __`tag` origin__ | n/a       | n/a       | n/a       | n/a       | n/a       | n/a       |
 
 ---
@@ -81,7 +81,7 @@ This one is easy: `tag` variables are opaque! They can't be read from.
 
 ## Writing to the field of an object
 
-Like reading the field of an object, writing to a field depends on the reference capability of the object reference being stored and the reference capability of the origin object containing the field. The reference capability of the object being stored must not violate the guarantees made by the origin object's reference capability. For example, a val object reference can be stored in an `iso` origin. This is because the val reference capability guarantees that no alias to that object exists which could violate the guarantees that the `iso` capability makes.
+Like reading the field of an object, writing to a field depends on the reference capability of the object reference being stored and the reference capability of the origin object containing the field. The reference capability of the object being stored must not violate the guarantees made by the origin object's reference capability. For example, a `val` object reference can be stored in an `iso` origin. This is because the `val` reference capability guarantees that no alias to that object exists which could violate the guarantees that the `iso` capability makes.
 
 Here's a simplified version of the table above that shows which reference capabilities can be stored in the field of an origin object.
 

--- a/docs/reference-capabilities/reference-capabilities.md
+++ b/docs/reference-capabilities/reference-capabilities.md
@@ -105,7 +105,7 @@ __So do I have to specify a reference capability when I define a type?__ Only if
 
 ## How to create objects with different capabilities
 
-When you write a constructor, by default, that constructor will either create a new object with `ref` or `tag` as the capability. In the case of actors, the constructor will always create a `tag`. For classes, if defaults to `ref` but you can create with other capabilities. Let's take a look at an example:
+When you write a constructor, by default, that constructor will either create a new object with `ref` or `tag` as the capability. In the case of actors, the constructor will always create a `tag`. For classes, it defaults to `ref` but you can create with other capabilities. Let's take a look at an example:
 
 ```pony
 class Foo


### PR DESCRIPTION
I found some words like "val" and "tag" without back-ticks and one specific line where "if" was written instead of "it"