### PR TITLE
Update `with` documentation to match new implementation

### DIFF
--- a/docs/expressions/errors.md
+++ b/docs/expressions/errors.md
@@ -108,16 +108,6 @@ class SomeObjectThatNeedsDisposing
     // release resources
 ```
 
-It is possible to provide an `else` clause, which is called only in error cases:
-
-```pony
-with obj = SomeObjectThatNeedsDisposing() do
-  // use obj
-else
-  // only run if an error has occurred
-end
-```
-
 Multiple objects can be set up for disposal:
 
 ```pony
@@ -126,7 +116,7 @@ with obj = SomeObjectThatNeedsDisposing(), other = SomeOtherDisposableObject() d
 end
 ```
 
-The value of a `with` expression is the value of the last expression in the block, or of the last expression in the `else` block if there is one and an error occurred.
+The value of a `with` expression is the value of the last expression in the block.
 
 ## Language constructs that can raise errors
 


### PR DESCRIPTION
There's no longer an `else` clause, it is purely `with`.

See https://github.com/ponylang/ponyc/pull/4024