### PR TITLE
Add missing return type to Compactable#size()

### DIFF
--- a/docs/types/traits-and-interfaces.md
+++ b/docs/types/traits-and-interfaces.md
@@ -194,7 +194,7 @@ Here's a contrived example:
 ```pony
 interface Compactable
   fun ref compact()
-  fun size()
+  fun size(): USize
 
 class Compactor
   """


### PR DESCRIPTION
This PR adds the missing `USize` return type to the `Compactable` interface's `size()` method. Without it, the example fails with a compile error:

```
❯ ponyc
Building builtin -> /home/djavorszky/.local/share/ponyup/ponyc-release-0.49.0-x86_64-linux-gnu/packages/builtin
Building . -> /home/djavorszky/dev/helloworld
Error:
/home/djavorszky/dev/helloworld/main.pony:74:21: couldn't find 'gt' in 'None'
    if thing.size() > _threshold then
```