### PR TITLE
Remove extraneous ‘that’

### DIFF
--- a/docs/reference-capabilities/reference-capabilities.md
+++ b/docs/reference-capabilities/reference-capabilities.md
@@ -129,4 +129,4 @@ class Foo
     x = x'
 ```
 
-But, that's probably not what you'd really want to do. Better to use the capabilities recovery facilities of Pony that we'll cover that later in the [Recovering Capabilities](/reference-capabilities/recovering-capabilities.md) section.
+But, that's probably not what you'd really want to do. Better to use the capabilities recovery facilities of Pony that we'll cover later in the [Recovering Capabilities](/reference-capabilities/recovering-capabilities.md) section.


### PR DESCRIPTION
Looks like this was once “we’ll cover that” and was supposed to be switched to “that we’ll cover”, but… well, that’s that.