### PR TITLE
Generic 'get' function should have default refcap

### DIFF
--- a/docs/generics/generic-constraints.md
+++ b/docs/generics/generic-constraints.md
@@ -27,7 +27,7 @@ class Foo[A: Any #read]
   new create(c: A) =>
     _c = c
 
-  fun ref get(): this->A => _c
+  fun get(): this->A => _c
 
   fun ref set(c: A) => _c = c
 


### PR DESCRIPTION
Having `fun ref get(): this->A => _c` results in compile error:

> Error:
/home/djavorszky/dev/helloworld/main.pony:7:18: can only use 'this' for a viewpoint in a box function
  fun ref get(): this->A => _c

Works with `fun get(): this->A => _c`