### PR TITLE
Fix Pony and C code for jump consistent hash

### DIFF
--- a/docs/c-ffi/c-abi.md
+++ b/docs/c-ffi/c-abi.md
@@ -6,20 +6,21 @@ The FFI support in Pony uses the C application binary interface (ABI) to interfa
 
 Writing your own C library for use by Pony is almost as easy as using existing libraries.
 
-Let's look at a complete example of a C function we may wish to provide to Pony. A Jump Consistent Hash, for example, could be provided in pure Pony as follows:
+Let's look at a complete example of a C function we may wish to provide to Pony. Let's consider a pure Pony implementation of a [Jump Consistent Hash](https://arxiv.org/abs/1406.2294):
 
 ```pony
 // Jump consistent hashing in Pony, with an inline pseudo random generator
+// https://arxiv.org/abs/1406.2294
 
-fun jch(key: U64, buckets: I64): I32 =>
+fun jch(key: U64, buckets: U32): I32 =>
   var k = key
   var b = I64(0)
   var j = I64(0)
 
-  while j < buckets do
+  while j < buckets.i64() do
     b = j
     k = (k * 2862933555777941757) + 1
-    j = ((b + 1).f64() * (U32(1 << 31).f64() / ((key >> 33) + 1).f64())).i64()
+    j = ((b + 1).f64() * (I64(1 << 31).f64() / ((k >> 33) + 1).f64())).i64()
   end
 
   b.i32()
@@ -45,29 +46,18 @@ The implementation of the previous header would be something like:
 
 ```c
 #include <stdint.h>
-#include <limits.h>
-#include "math.h"
 
-// A reasonably fast, good period, low memory use, xorshift64* based prng
-double lcg_next(uint64_t* x)
-{
-  *x ^= *x >> 12;
-  *x ^= *x << 25;
-  *x ^= *x >> 27;
-  return (double)(*x * 2685821657736338717LL) / ULONG_MAX;
-}
-
-// Jump consistent hash
+// A fast, minimal memory, consistent hash algorithm
+// https://arxiv.org/abs/1406.2294
 int32_t jch_chash(uint64_t key, uint32_t num_buckets)
 {
-  uint64_t seed = key;
   int b = -1;
-  int32_t j = 0;
+  uint64_t j = 0;
 
   do {
     b = j;
-    double r = lcg_next(&seed);
-    j = floor((b + 1)/r);
+    key = key * 2862933555777941757ULL + 1;
+    j = (b + 1) * ((double)(1LL << 31) / ((double)(key >> 33) + 1));
   } while(j < num_buckets);
 
   return (int32_t)b;
@@ -78,7 +68,7 @@ We need to compile the native code to a shared library. This example is for MacO
 
 ```bash
 clang -fPIC -Wall -Wextra -O3 -g -MM jch.c >jch.d
-clang -fPIC -Wall -Wextra -O3 -g   -c -o jch.o jch.c
+clang -fPIC -Wall -Wextra -O3 -g  -c -o jch.o jch.c
 clang -shared -lm -o libjch.dylib jch.o
 ```
 
@@ -92,7 +82,6 @@ support
 
 use "lib:jch"
 use "collections"
-use "random"
 use @jch_chash[I32](hash: U64, bucket_size: U32)
 
 actor Main
@@ -102,13 +91,31 @@ actor Main
     _env = env
 
     let bucket_size: U32 = 1000000
-    var random = MT
 
+    _env.out.print("C implementation:")
     for i in Range[U64](1, 20) do
-      let r: U64 = random.next()
       let hash = @jch_chash(i, bucket_size)
       _env.out.print(i.string() + ": " + hash.string())
     end
+
+    _env.out.print("Pony implementation:")
+    for i in Range[U64](1, 20) do
+      let hash = jch(i, bucket_size)
+      _env.out.print(i.string() + ": " + hash.string())
+    end
+
+  fun jch(key: U64, buckets: U32): I32 =>
+    var k = key
+    var b = I64(0)
+    var j = I64(0)
+
+    while j < buckets.i64() do
+      b = j
+      k = (k * 2862933555777941757) + 1
+      j = ((b + 1).f64() * (I64(1 << 31).f64() / ((k >> 33) + 1).f64())).i64()
+    end
+
+    b.i32()
 ```
 
 We can now use ponyc to compile a native executable integrating Pony and our C library. And that's all we need to do.


### PR DESCRIPTION
The Pony version was implementing a buggy version of
https://arxiv.org/abs/1406.2294, while the C version was implementing a
different version, albeit incompatible, from the same paper.

---

Fixes #181 