### PR TITLE
Brought examples up to date with current Pony syntax and package requirements.

### DIFF
--- a/docs/appendices/examples.md
+++ b/docs/appendices/examples.md
@@ -129,8 +129,8 @@ class iso _TestAddition is UnitTest
   """
   fun name(): String => "u32/add"
 
-  fun apply(h: TestHelper): TestResult =>
-    h.expect_eq[U32](2 + 2, 4)
+  fun apply(h: TestHelper) =>
+    h.assert_eq[U32](2 + 2, 4)
 ```
 
 Some assertions you can make with `TestHelper` are

--- a/docs/expressions/control-structures.md
+++ b/docs/expressions/control-structures.md
@@ -140,7 +140,7 @@ actor Main
       else
         "no names!"
       end
-    env.out.print("x is " + s)
+    env.out.print("x is " + x)
 ```
 
 And finally, here the value of __x__ is "no names!"

--- a/docs/gotchas/garbage-collection.md
+++ b/docs/gotchas/garbage-collection.md
@@ -15,8 +15,10 @@ Garbage collection is never attempted on any actor while it is executing a behav
 Here's a typical "I'm learning Pony" program:
 
 ```pony
+use "collections"
+
 actor Main
-  new create(env: Env)
+  new create(env: Env) =>
     for i in Range(1, 2_000_000) do
       ... something that uses up heap ...
     end

--- a/docs/pattern-matching/match.md
+++ b/docs/pattern-matching/match.md
@@ -69,6 +69,9 @@ class Foo
     _x == that._x
 
 actor Main
+  new create(env: Env) =>
+    None
+
   fun f(x: Foo): String =>
     match x
     | Foo(1) => "one"


### PR DESCRIPTION
* appendices/examples.md - UnitTest.apply() returns None, not TestResult.
  expect_eq method is now assert_eq
* expressions/control-structures.md - typo in the variable name.
* gotchas/garbage_collection.md - Missing => in constructor line,
  missing use "collections" needed for Range.
* pattern-matching/match.md - Mandatory constructor for Main added.