### PR TITLE
Set lint for unordered list indentation to 4 spaces

### DIFF
--- a/.github/linters/.markdown-lint.yml
+++ b/.github/linters/.markdown-lint.yml
@@ -1,4 +1,5 @@
 {
+  "MD007": { "indent": 4 },
   "MD013": false,
   "MD026": false
 }


### PR DESCRIPTION
The default value is 2, but mkdocs needs at least 4 spaces in order to correctly
render nested lists. See https://github.com/mkdocs/mkdocs/issues/545 for more
details.