### PR TITLE
Advertise Markdown files in docs/ as "source" files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+docs/** -linguist-documentation
+docs/**/*.md linguist-detectable


### PR DESCRIPTION
Right now GitHub does not detect the language of this repo:
![image](https://github.com/ponylang/pony-tutorial/assets/25753618/b3c0534e-6354-4085-ad19-d69affabc336)

After the fix it will identify Markdown as the main language:
![image](https://github.com/ponylang/pony-tutorial/assets/25753618/b60b430a-8679-499a-a177-544c0e546385)
![image](https://github.com/ponylang/pony-tutorial/assets/25753618/a7d54f8d-a9b8-4444-9664-b81353b9bc63)

In my opinion, this will help people (e.g. documentation writers and beginner programmers) to find a project to contribute to.