### PR TITLE
Build the tutorial nightly to get alerts if it fails

### DIFF
--- a/.github/workflows/verify-site-builds.yml
+++ b/.github/workflows/verify-site-builds.yml
@@ -1,0 +1,31 @@
+name: Verify site builds
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 2 * * *'
+
+jobs:
+  test:
+    name: Verify site builds
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@v3
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+        env:
+          INSIDERS_PAT: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
+      - name: Build site
+        run: mkdocs build
+      - name: Send alert on failure
+        if: ${{ failure() }}
+        uses: zulip/github-actions-zulip/send-message@b62d5a0e48a4d984ea4fce5dd65ba691963d4db4
+        with:
+          api-key: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_API_KEY }}
+          email: ${{ secrets.ZULIP_SCHEDULED_JOB_FAILURE_EMAIL }}
+          organization-url: 'https://ponylang.zulipchat.com/'
+          to: notifications
+          type: stream
+          topic: ${{ github.repository }} scheduled job failure
+          content: ${{ github.server_url}}/${{ github.repository }}/actions/runs/${{ github.run_id }} failed.


### PR DESCRIPTION
Currently, a person opening a PR can be surprised by failures unrelated
to their changes. In particular, to URLs that are external to the site
no longer working and failing validation.

Worse, this means that users of the tutorial are experiencing broken
URLs that won't be discovered until someone does an update for the
tutorial and the build fails.

This commit adds a nightly job that tries to build the site and if it
fails, alerts to Zulip so we can be made aware of issues in a timely
fashion and can endeavor to fix them as soon as possible.

The workflow can also be triggered manually if need be.