### PR TITLE
calling-c: elaborate on the x_dpy example

### DIFF
--- a/docs/c-ffi/calling-c.md
+++ b/docs/c-ffi/calling-c.md
@@ -80,7 +80,8 @@ use @eglGetDisplay[Pointer[_EGLDisplayHandle]](disp: Pointer[_XDisplayHandle])
 primitive _XDisplayHandle
 primitive _EGLDisplayHandle
 
-let x_dpy = @XOpenDisplay(Pointer[U8])
+let x_dpy_name: String = // ...
+let x_dpy = @XOpenDisplay(x_dpy_name.cstring())
 if x_dpy.is_null() then
   env.out.print("XOpenDisplay failed")
 end


### PR DESCRIPTION
The following code is not valid Pony code

    let x_dpy = @XOpenDisplay(Pointer[U8])