### PR TITLE
Improve example of `with` block with multiple objects

### DIFF
--- a/docs/expressions/errors.md
+++ b/docs/expressions/errors.md
@@ -112,7 +112,7 @@ Multiple objects can be set up for disposal:
 
 ```pony
 with obj = SomeObjectThatNeedsDisposing(), other = SomeOtherDisposableObject() do
-  // use obj
+  // use obj and other
 end
 ```
 


### PR DESCRIPTION
Emphasize that all disposable objects listed in the first line of `with` block can be used within the block.