### PR TITLE
Use same (combined) icon for both color schemes

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -61,7 +61,7 @@ theme:
       primary: brown
       accent: amber
       toggle:
-        icon: material/toggle-switch-off-outline
+        icon: material/brightness-4
         name: Switch to dark mode
 
     # Dark mode
@@ -69,7 +69,7 @@ theme:
       primary: brown
       accent: amber
       toggle:
-        icon: material/toggle-switch
+        icon: material/brightness-4
         name: Switch to light mode
 
 nav:


### PR DESCRIPTION
… to make the color mode switcher more perceptible

As discussed in https://github.com/ponylang/ponylang-website/pull/979#issuecomment-2021203578