### PR TITLE
Stop using mkdocs-material insiders build

### DIFF
--- a/.github/workflows/verify-site-builds.yml
+++ b/.github/workflows/verify-site-builds.yml
@@ -17,8 +17,6 @@ jobs:
         uses: actions/checkout@v4.1.1
       - name: Install dependencies
         run: pip install -r requirements.txt
-        env:
-          INSIDERS_PAT: ${{ secrets.MATERIAL_INSIDERS_ACCESS }}
       - name: Build site
         run: mkdocs build
       - name: Send alert on failure

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-git+https://${INSIDERS_PAT}@github.com/squidfunk/mkdocs-material-insiders.git
+mkdocs-material
 mkdocs-htmlproofer-plugin>=0.1.0
 mkdocs-ezlinks-plugin>=0.1.8


### PR DESCRIPTION
It is now all public. https://squidfunk.github.io/mkdocs-material/blog/2025/11/11/insiders-now-free-for-everyone/.