### PR TITLE
Disable external URL validation in Netlify builds

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -12,6 +12,7 @@ ID = "Your_Site_ID"
 
 [build.environment]
   PYTHON_VERSION = "3.12"
+  VALIDATE_EXTERNAL_URLS = "false"
 
 [[redirects]]
   from = "/expressions/exceptions.html"


### PR DESCRIPTION
Sets `VALIDATE_EXTERNAL_URLS=false` in the Netlify build environment to prevent spurious build failures from transient network errors and rate limiting by third-party sites.