### PR TITLE
Disable htmlproofer in Netlify builds

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -35,6 +35,7 @@ plugins:
   - search
   - ezlinks
   - htmlproofer:
+      enabled: !ENV [ENABLED_HTMLPROOFER, True]
       raise_error: True
       raise_error_excludes:
         429: ["https://github.com/ponylang", "https://web.archive.org/*"]

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,7 @@ ID = "Your_Site_ID"
 
 [build.environment]
   PYTHON_VERSION = "3.12"
-  VALIDATE_EXTERNAL_URLS = "false"
+  ENABLED_HTMLPROOFER="false"
 
 [[redirects]]
   from = "/expressions/exceptions.html"


### PR DESCRIPTION
Adds `!ENV [ENABLED_HTMLPROOFER, True]` wiring to the htmlproofer plugin config so the env var in `netlify.toml` actually controls the plugin. Replaces `VALIDATE_EXTERNAL_URLS` which had no effect without similar wiring.

Matches the ponylang-website and pony-patterns setup.