### PR TITLE
Remove htmlproofer plugin

### DIFF
--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -34,13 +34,6 @@ markdown_extensions:
 plugins:
   - search
   - ezlinks
-  - htmlproofer:
-      enabled: !ENV [ENABLED_HTMLPROOFER, True]
-      raise_error: True
-      raise_error_excludes:
-        429: ["https://github.com/ponylang", "https://web.archive.org/*"]
-        404: ["https://github.com/ponylang"]
-        403: ["https://readthedocs.org"]
   - llmstxt:
       full_output: llms-full.txt
       markdown_description: >-

--- a/netlify.toml
+++ b/netlify.toml
@@ -12,7 +12,6 @@ ID = "Your_Site_ID"
 
 [build.environment]
   PYTHON_VERSION = "3.12"
-  ENABLED_HTMLPROOFER="false"
 
 [[redirects]]
   from = "/expressions/exceptions.html"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
 mkdocs-material==9.7.1
-mkdocs-htmlproofer-plugin>=0.1.0
 mkdocs-ezlinks-plugin>=0.1.8
 mkdocs-llmstxt==0.5.0


### PR DESCRIPTION
The htmlproofer link checking fails frequently on valid URLs due to rate limiting, transient errors, and sites that block automated requests. This creates noise in CI without catching real issues. Remove the plugin and all associated configuration.