### PR TITLE
Recommend claude-opus-4-6 for prose

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -24,6 +24,10 @@ When you start working on this project, load the `pony-skills` skill — it tell
 Read [CONTRIBUTING.md](CONTRIBUTING.md).
 <!-- /contributor-only -->
 
+## Prose model
+
+If you are running on an Anthropic model, use `claude-opus-4-6` for writing comments, documentation, and other prose. Prose quality from Anthropic models dropped starting with Opus 4.7 and has gotten worse with each subsequent release.
+
 ## Local Verification
 
 - **mkdocs**: Run via venv (`pip install -r requirements.txt`, then `mkdocs serve` or `mkdocs build`)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,8 @@ What we won't do is teach an AI. If a PR's open questions can only be resolved b
 
 You don't have to disclose AI use, though saying so up front often makes review faster. What you do have to do is stand behind the work. If you can't answer questions about why your PR looks the way it does, it isn't ready.
 
+If you or your AI assistant are using an Anthropic model, use `claude-opus-4-6` for writing comments, documentation, and other prose. We've found that prose quality from Anthropic models started dropping with Opus 4.7 and has gotten worse with each subsequent release.
+
 ### Junk PRs
 
 This isn't new policy. Long before AI tools were any good, low-effort PRs that wasted maintainer time could get a contributor blocked. That hasn't changed. What's changed is how easy it has become to produce a junk PR. One won't get you blocked. A pattern of them will. How many makes a pattern is our call.


### PR DESCRIPTION
Prose quality from Anthropic models started dropping with Opus 4.7 and has gotten worse with each subsequent release. This adds guidance to use claude-opus-4-6 for comments, documentation, and other prose work.