### PR TITLE
Replace super-linter with dedicated linter images

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -10,19 +10,13 @@ permissions:
   packages: read
 
 jobs:
-  superlinter:
-    name: Lint markdown and yaml
+  lint-markdown:
+    name: Lint markdown
     runs-on: ubuntu-latest
     steps:
-      - name: Checkout source
-        uses: actions/checkout@v6.0.2
-      - name: Lint codebase
-        uses: docker://github/super-linter:v3.8.3
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          VALIDATE_ALL_CODEBASE: true
-          VALIDATE_MD: true
-          VALIDATE_YAML: true
+      - uses: actions/checkout@v6.0.2
+      - name: Lint markdown
+        uses: docker://ghcr.io/ponylang/shared-docker-ci-markdownlint:20260810
 
   check-spelling:
     name: Spellcheck markdown

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -3,5 +3,7 @@
   "MD013": false,
   "MD026": false,
   "MD033": { "allowed_elements": ["sup"] },
-  "MD051": false
+  "MD050": false,
+  "MD051": false,
+  "MD056": false
 }

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -3,6 +3,7 @@
   "MD013": false,
   "MD026": false,
   "MD033": { "allowed_elements": ["sup"] },
+  "MD049": false,
   "MD050": false,
   "MD051": false,
   "MD056": false

--- a/.markdownlint.yml
+++ b/.markdownlint.yml
@@ -2,5 +2,6 @@
   "MD007": { "indent": 4 },
   "MD013": false,
   "MD026": false,
-  "MD033": { "allowed_elements": ["sup"] }
+  "MD033": { "allowed_elements": ["sup"] },
+  "MD051": false
 }


### PR DESCRIPTION
Replace the super-linter Docker image with a dedicated markdownlint image from shared-docker. Faster CI — small purpose-built image instead of the 2GB+ super-linter.