### PR TITLE
Update code samples and prose for ponyc 0.70.0 constraint cap change

### DIFF
--- a/code-samples/appendices-examples-test-helper.pony
+++ b/code-samples/appendices-examples-test-helper.pony
@@ -9,7 +9,7 @@ fun tag assert_error(test: ITest, msg: String = "") ?
 fun tag expect_error(test: ITest box, msg: String = ""): Bool
 fun tag assert_is (expect: Any, actual: Any, msg: String = "") ?
 fun tag expect_is (expect: Any, actual: Any, msg: String = ""): Bool
-fun tag assert_eq[A: (Equatable[A] #read & Stringable)]
+fun tag assert_eq[A: (Equatable[A] #read & Stringable #read)]
   (expect: A, actual: A, msg: String = "") ?
-fun tag expect_eq[A: (Equatable[A] #read & Stringable)]
+fun tag expect_eq[A: (Equatable[A] #read & Stringable #read)]
   (expect: A, actual: A, msg: String = ""): Bool

--- a/code-samples/control-structures-iftype-capability.pony
+++ b/code-samples/control-structures-iftype-capability.pony
@@ -14,7 +14,7 @@ actor Main
     let cat2: Cat val = Cat
     maybe_rename[Cat val](cat2, env)
 
-  fun maybe_rename[A: Animal](a: A, env: Env) =>
+  fun maybe_rename[A: Animal #any](a: A, env: Env) =>
     iftype A <: Cat ref then
       a.set_name("Kitty")
       env.out.print(a.name())

--- a/code-samples/generics-and-reference-capabilities-explicit-constraint-and-default-capability.pony
+++ b/code-samples/generics-and-reference-capabilities-explicit-constraint-and-default-capability.pony
@@ -1,1 +1,1 @@
-class Foo[A: Any]
+class Foo[A: Any #any]

--- a/docs/generics/generics-and-reference-capabilities.md
+++ b/docs/generics/generics-and-reference-capabilities.md
@@ -6,7 +6,7 @@ In the examples presented previously we've explicitly set the reference capabili
 --8<-- "generics-foo-with-any-val.pony::1"
 ```
 
-If the capability is left out of the type parameter then the generic class or function can accept any reference capability. This would look like:
+To accept any reference capability, use `#any` as the capability on the constraint. This would look like:
 
 ```pony
 --8<-- "generics-and-reference-capabilities-explicit-constraint-and-default-capability.pony"


### PR DESCRIPTION
ponyc 0.70.0 uses the default capability of named types in type parameter constraints instead of substituting `#any`. Code samples and prose that relied on the implicit `#any` need updating.

Changes:
- `control-structures-iftype-capability.pony`: `A: Animal` → `A: Animal #any` (the example passes both `Cat ref` and `Cat val`, so needs any-cap)
- `appendices-examples-test-helper.pony`: `Stringable` → `Stringable #read` (matches `Equatable[A] #read` on the other side)
- `generics-and-reference-capabilities-explicit-constraint-and-default-capability.pony`: `A: Any` → `A: Any #any`
- Tutorial prose updated to say "use `#any`" instead of "leave out the capability"
