### PR TITLE
Update ponycheck example link for ponyc examples reorganization

### DIFF
--- a/docs/testing/ponycheck.md
+++ b/docs/testing/ponycheck.md
@@ -50,6 +50,6 @@ It is also possible to integrate any number of properties directly into one
 
 ## Additional resources
 
-You can learn more about PonyCheck specifics by checking out the [API documentation](https://stdlib.ponylang.io/pony_check--index/). You can also find some [example tests](https://github.com/ponylang/ponyc/tree/main/examples/pony_check) in [ponyc GitHub repository](https://github.com/ponylang/ponyc).
+You can learn more about PonyCheck specifics by checking out the [API documentation](https://stdlib.ponylang.io/pony_check--index/). You can also find some [example tests](https://github.com/ponylang/ponyc/tree/main/examples/testing/pony_check) in [ponyc GitHub repository](https://github.com/ponylang/ponyc).
 
 To learn more about testing in Pony in general, there's a [testing section](http://patterns.ponylang.io/testing.html) in the [Pony Patterns](http://patterns.ponylang.io/) book which isn't specific to `PonyCheck`.


### PR DESCRIPTION
ponylang/ponyc#6035 moves examples into category subdirectories.
The PonyCheck example link in the testing docs points to the old
flat path; this updates it to the new `examples/testing/pony_check`
location.